### PR TITLE
Fix/loan module integrations

### DIFF
--- a/contracts/interfaces/IInterestRate.sol
+++ b/contracts/interfaces/IInterestRate.sol
@@ -1,12 +1,9 @@
 import { LoanLib } from "../utils/LoanLib.sol";
-import { IModule } from "./IModule.sol";
 
-interface IInterestRate is IModule {
+interface IInterestRate {
   function accrueInterest(
     bytes32 positionId, 
     uint256 amount, 
     LoanLib.STATUS currentStatus
   ) external returns(uint256);
-
-  function healthcheck() external returns (LoanLib.STATUS status);
 }

--- a/contracts/interfaces/IInterestRate.sol
+++ b/contracts/interfaces/IInterestRate.sol
@@ -3,7 +3,7 @@ import { IModule } from "./IModule.sol";
 
 interface IInterestRate is IModule {
   function accrueInterest(
-    uint256 lenderId, 
+    bytes32 positionId, 
     uint256 amount, 
     LoanLib.STATUS currentStatus
   ) external returns(uint256);

--- a/contracts/interfaces/ILoan.sol
+++ b/contracts/interfaces/ILoan.sol
@@ -1,5 +1,3 @@
-import { IModule } from "./IModule.sol";
-import { IModule } from "./IModule.sol";
 import { LoanLib } from "../utils/LoanLib.sol";
 
 interface ILoan {

--- a/contracts/interfaces/ILoan.sol
+++ b/contracts/interfaces/ILoan.sol
@@ -34,7 +34,6 @@ interface ILoan {
   function withdraw(bytes32 positionId, uint256 amount) external returns(bool);
   function borrow(bytes32 positionId, uint256 amount) external returns(bool);
   function close(bytes32 positionId) external returns(bool);
-  function emergencyClose(bytes32 positionId) external returns(bool);
 
   function depositAndRepay(bytes32 positionId, uint256 amount) external returns(bool);
   function depositAndClose(bytes32 positionId) external returns(bool);
@@ -46,5 +45,7 @@ interface ILoan {
 
   function accrueInterest() external returns(uint256 amountAccrued);
   function getOutstandingDebt() external returns(uint256 totalDebt);
+
+  function healthcheck() external returns(LoanLib.STATUS);
   // function liquidate() external returns(uint256 totalValueLiquidated);
 }

--- a/contracts/interfaces/ILoan.sol
+++ b/contracts/interfaces/ILoan.sol
@@ -2,7 +2,7 @@ import { IModule } from "./IModule.sol";
 import { IModule } from "./IModule.sol";
 import { LoanLib } from "../utils/LoanLib.sol";
 
-interface ILoan is IModule {
+interface ILoan {
   // Stakeholder data
   struct DebtPosition {
     address lender;           // person to repay

--- a/contracts/interfaces/IModule.sol
+++ b/contracts/interfaces/IModule.sol
@@ -1,9 +1,0 @@
-pragma solidity 0.8.9;
-
-import { LoanLib } from "../utils/LoanLib.sol";
-
-interface IModule {
-  function healthcheck() external returns (LoanLib.STATUS status);
-  function init() external returns(bool);
-  function loan() external returns (address);
-}

--- a/contracts/interfaces/IOracle.sol
+++ b/contracts/interfaces/IOracle.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.8.9;
-import { IModule } from "./IModule.sol";
 
-interface IOracle is IModule {
+interface IOracle {
     /** current price for token asset. denominated in USD + 18 decimals */
     function getLatestAnswer(address token) external returns(uint256);
 }

--- a/contracts/interfaces/ISpigotConsumer.sol
+++ b/contracts/interfaces/ISpigotConsumer.sol
@@ -1,7 +1,6 @@
 import { LoanLib } from "../utils/LoanLib.sol";
-import { IModule } from "./IModule.sol";
 
-interface ISpigotConsumer is IModule {
+interface ISpigotConsumer {
   
   function claimAndTrade(
     address claimToken, 
@@ -9,6 +8,4 @@ interface ISpigotConsumer is IModule {
     bytes calldata zeroExTradeData
   ) external returns(uint256 tokensBought);
   function stream(address lender, address token, uint256 amount) external returns(bool);
-
-  function healthcheck() external returns (LoanLib.STATUS status);
 }

--- a/contracts/modules/loan/BaseLoan.sol
+++ b/contracts/modules/loan/BaseLoan.sol
@@ -10,7 +10,6 @@ import { ILoan } from "../../interfaces/ILoan.sol";
 import { IEscrow } from "../../interfaces/IEscrow.sol";
 import { IOracle } from "../../interfaces/IOracle.sol";
 import { IInterestRate } from "../../interfaces/IInterestRate.sol";
-import { IModule } from "../../interfaces/IModule.sol";
 
 abstract contract BaseLoan is ILoan, MutualUpgrade {  
   address immutable public borrower;   // borrower being lent to

--- a/contracts/modules/loan/BaseLoan.sol
+++ b/contracts/modules/loan/BaseLoan.sol
@@ -143,6 +143,9 @@ abstract contract BaseLoan is ILoan, MutualUpgrade {
     );
   }
 
+  function healthcheck() external returns(LoanLib.STATUS) {
+    return _updateLoanStatus(_healthcheck());
+  }
   /**
    *  @notice - loops through all modules and returns their status if required last to savegas on override external calls
    *        returns early if returns non-ACTIVE

--- a/contracts/modules/loan/BaseLoan.sol
+++ b/contracts/modules/loan/BaseLoan.sol
@@ -397,26 +397,6 @@ abstract contract BaseLoan is ILoan, MutualUpgrade {
     return true;
   }
 
-
-  /**
-   * @dev - Allows lender to pull all funds from contract, realizing any losses from non-payment.
-   * @param positionId -the debt position to close
-  */
-  function emergencyClose(bytes32 positionId) override external returns(bool) {
-    DebtPosition memory debt = debts[positionId];
-    require(msg.sender == debt.lender);
-
-    if(debt.deposit > 0) {
-      uint256 availableFunds = IERC20(debt.token).balanceOf(address(this));
-      uint256 recoverableFunds = availableFunds > debt.deposit ? debt.deposit : availableFunds;
-      require(IERC20(debt.token).transfer(debt.lender, recoverableFunds));
-    }
-
-    require(_close(debt, positionId));
-    
-    return true;
-  }
-
   // prviliged interal functions
   /**
    * @dev - Reduces `principal` and/or `interestAccrued` on debt position, increases lender's `deposit`.

--- a/contracts/modules/loan/BaseLoan.sol
+++ b/contracts/modules/loan/BaseLoan.sol
@@ -266,7 +266,7 @@ abstract contract BaseLoan is ILoan, MutualUpgrade {
 
     // call method within escrow contract
     // releasing everything to debt DAO multisig to be dealt with OTC
-    IEscrow(escrow).releaseCollateral(amount, escrowToken, arbiter);
+    IEscrow(escrow).liquidate(amount, escrowToken, arbiter);
 
     emit Liquidated(positionId, amount, escrowToken);
   }

--- a/contracts/modules/loan/EscrowedLoan.sol
+++ b/contracts/modules/loan/EscrowedLoan.sol
@@ -40,6 +40,7 @@ abstract contract EscrowedLoan is ILoan {
     virtual internal
     returns(uint256)
   { 
+    // assumes Loan.liquidate is privileged function and sender is in charge of liquidating
     require(escrow.liquidate(amount, targetToken, msg.sender));
 
     emit Liquidated(positionId, amount, targetToken);

--- a/contracts/modules/loan/EscrowedLoan.sol
+++ b/contracts/modules/loan/EscrowedLoan.sol
@@ -13,7 +13,6 @@ abstract contract EscrowedLoan is ILoan {
     address _oracle,
     address _borrower
   ) {
-    // make sure you modules.push(escrow) in implementation contract constructor
     escrow = new Escrow(
       _minimumCollateralRatio,
       _oracle,
@@ -27,6 +26,7 @@ abstract contract EscrowedLoan is ILoan {
     if(escrow.getCollateralRatio() < escrow.minimumCollateralRatio()) {
       return LoanLib.STATUS.LIQUIDATABLE;
     }
+
     return LoanLib.STATUS.ACTIVE;
   }
 

--- a/contracts/modules/loan/MaximumSecurityLoan.sol
+++ b/contracts/modules/loan/MaximumSecurityLoan.sol
@@ -1,0 +1,56 @@
+import { SpigotedLoan } from "./SpigotedLoan.sol";
+import { EscrowedLoan } from "./EscrowedLoan.sol";
+import { BaseLoan } from "./BaseLoan.sol";
+import { LoanLib } from "../../utils/LoanLib.sol";
+
+/**
+ * @title Maximum Security Debt DAO Loan
+ * @author Kiba Gateaux
+ * @dev NOT FOR PRODUCTION USE
+ * @notice Used to test new features to ensure lender returns
+ */
+contract MaximumSecurityLoan is SpigotedLoan, EscrowedLoan {
+  constructor(
+    uint256 maxDebtValue_,
+    uint256 minimumCollateralRatio_,
+    address oracle_,
+    address arbiter_,
+    address borrower_,
+    address interestRateModel_,
+    address spigot_
+  )
+    EscrowedLoan(minimumCollateralRatio_, oracle, borrower)
+    SpigotedLoan(
+      maxDebtValue_,
+      oracle_,
+      arbiter_,
+      borrower_,
+      interestRateModel_,
+      spigot_
+    )
+  {
+    modules.push(address(escrow));
+    modules.push(address(spigot));
+  }
+
+  function _healthcheck() override(EscrowedLoan, BaseLoan) internal returns(LoanLib.STATUS) {
+    // check cheap calls usingi nternal data first
+    if(BaseLoan._healthcheck() != LoanLib.STATUS.ACTIVE) {
+      return BaseLoan._healthcheck();
+    }
+    // then call external contracts 
+    return EscrowedLoan._healthcheck();
+  }
+
+  function _liquidate(
+    DebtPosition memory debt,
+    uint256 amount,
+    address targetToken
+  ) override(EscrowedLoan, BaseLoan) internal returns(uint256) {
+    return EscrowedLoan._liquidate(
+      debt,
+      amount,
+      targetToken
+    );
+  }
+}

--- a/contracts/modules/loan/MaximumSecurityLoan.sol
+++ b/contracts/modules/loan/MaximumSecurityLoan.sol
@@ -42,9 +42,10 @@ contract MaximumSecurityLoan is SpigotedLoan, EscrowedLoan {
 
   function _liquidate(
     DebtPosition memory debt,
+    bytes32 positionId,
     uint256 amount,
     address targetToken
-  ) override(EscrowedLoan, BaseLoan) internal returns(uint256) {
+  ) override(BaseLoan, EscrowedLoan) internal returns(uint256) {
     return EscrowedLoan._liquidate(
       debt,
       amount,

--- a/contracts/modules/loan/MaximumSecurityLoan.sol
+++ b/contracts/modules/loan/MaximumSecurityLoan.sol
@@ -29,17 +29,15 @@ contract MaximumSecurityLoan is SpigotedLoan, EscrowedLoan {
       spigot_
     )
   {
-    modules.push(address(escrow));
-    modules.push(address(spigot));
-  }
 
+  }
   function _healthcheck() override(EscrowedLoan, BaseLoan) internal returns(LoanLib.STATUS) {
     // check cheap calls usingi nternal data first
     if(BaseLoan._healthcheck() != LoanLib.STATUS.ACTIVE) {
-      return BaseLoan._healthcheck();
+      return _updateLoanStatus(BaseLoan._healthcheck());
     }
     // then call external contracts 
-    return EscrowedLoan._healthcheck();
+    return _updateLoanStatus(EscrowedLoan._healthcheck());
   }
 
   function _liquidate(

--- a/contracts/modules/loan/SpigotedLoan.sol
+++ b/contracts/modules/loan/SpigotedLoan.sol
@@ -30,16 +30,8 @@ contract SpigotedLoan is BaseLoan {
     maxDebtValue = maxDebtValue_;
 
     spigot = spigot_;
-    modules[modules.length] = spigot_;
 
     loanStatus = LoanLib.STATUS.INITIALIZED;
-  }
-
-  /**
-   * @notice see BaseLoan._init()
-  */
-  function init() virtual external returns(bool) {
-    return _init();
   }
 
 

--- a/contracts/modules/loan/SpigotedLoan.sol
+++ b/contracts/modules/loan/SpigotedLoan.sol
@@ -5,7 +5,7 @@ import { BaseLoan } from "./BaseLoan.sol";
 import { LoanLib } from "../../utils/LoanLib.sol";
 import { ISpigotConsumer } from "../../interfaces/ISpigotConsumer.sol";
 
-contract SpigotLoan is BaseLoan {
+contract SpigotedLoan is BaseLoan {
   address public spigot;
 
     /**
@@ -15,7 +15,6 @@ contract SpigotLoan is BaseLoan {
    * @param spigot_ - contract securing/repaying loan from borrower revenue streams
    * @param arbiter_ - neutral party with some special priviliges on behalf of borrower and lender
    * @param borrower_ - the debitor for all debt positions in this contract
-   * @param escrow_ - contract holding all collateral for borrower
    * @param interestRateModel_ - contract calculating lender interest from debt position values
   */
   constructor(
@@ -23,11 +22,10 @@ contract SpigotLoan is BaseLoan {
     address oracle_,
     address arbiter_,
     address borrower_,
-    address escrow_,
     address interestRateModel_,
     address spigot_
   )
-    BaseLoan(maxDebtValue_, oracle_, arbiter_, borrower_, escrow_, interestRateModel_)
+    BaseLoan(maxDebtValue_, oracle_, arbiter_, borrower_, interestRateModel_)
   {
     maxDebtValue = maxDebtValue_;
 

--- a/contracts/modules/loan/SpigotedLoan.sol
+++ b/contracts/modules/loan/SpigotedLoan.sol
@@ -34,15 +34,6 @@ contract SpigotedLoan is BaseLoan {
     loanStatus = LoanLib.STATUS.INITIALIZED;
   }
 
-
-  /**
-   * @notice see BaseLoan._healthcheck()
-  */
-  function healthcheck() virtual external returns(LoanLib.STATUS) {
-    return _healthcheck();
-  }
-
-
  /**
    * @dev - Claims revenue tokens from Spigot attached to borrowers revenue generating tokens
             and sells them via 0x protocol to repay debts


### PR DESCRIPTION
Fixes #27 
- modifies internal function hooks to allow previous hardcoded functionality (namely `liquidate`) to be added in by Loan flavors (namely Escrow to liquidate assets)
- moves Escrow contract out of BaseLoan into optional module 
- removes IModule system
- removes modules[] variable from BaseLoan
- removes init() and _init() from BaseLoan
- removes _getUsdValue() and just use _getTokenPrice
- updates loan status update system
- adds `MaximumSecurityLoan` as a sample implementation contract to test integrating various modules into final product