### PR TITLE
Add integration testing loan -> escrow

### DIFF
--- a/contracts/modules/loan/BaseLoan.sol
+++ b/contracts/modules/loan/BaseLoan.sol
@@ -301,8 +301,7 @@ abstract contract BaseLoan is ILoan, MutualUpgrade {
       'Loan: cant borrow'
     );
 
-    bool success = IERC20(debt.token).transferFrom(
-      address(this),
+    bool success = IERC20(debt.token).transfer(
       borrower,
       amount
     );

--- a/contracts/modules/loan/BasicEscrowedLoan.sol
+++ b/contracts/modules/loan/BasicEscrowedLoan.sol
@@ -1,0 +1,54 @@
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { LoanLib } from "../../utils/LoanLib.sol";
+import { EscrowedLoan } from "./EscrowedLoan.sol";
+import { RevolverLoan } from "./RevolverLoan.sol";
+import { BaseLoan } from "./BaseLoan.sol";
+import { ILoan } from "../../interfaces/ILoan.sol";
+
+contract BasicEscrowedLoan is RevolverLoan, EscrowedLoan {
+
+    constructor(
+        uint256 maxDebtValue_,
+        address oracle_,
+        address arbiter_,
+        address borrower_,
+        address interestRateModel_,
+        uint minCollateral_
+    ) RevolverLoan(
+        maxDebtValue_,
+        oracle_,
+        arbiter_,
+        borrower_,
+        interestRateModel_
+    ) EscrowedLoan(
+        minCollateral_,
+        oracle_,
+        borrower_
+    ) {
+
+    }
+
+    function _getInterestPaymentAmount(bytes32 positionId) override internal returns(uint256)
+    {
+        // NB: overriden so that _accrueInterest (out of scope) does not revert
+        return 0;
+    }
+
+    /** @dev see BaseLoan._liquidate */
+    function _liquidate(
+        bytes32 positionId,
+        uint256 amount,
+        address targetToken
+    )
+    internal override(BaseLoan, EscrowedLoan)
+    returns(uint256)
+    {
+        return EscrowedLoan._liquidate(positionId, amount, targetToken);
+    }
+
+    /** @dev see BaseLoan._healthcheck */
+    function _healthcheck() internal override(EscrowedLoan, BaseLoan) returns(LoanLib.STATUS) {
+        return EscrowedLoan._healthcheck();
+    }
+
+}

--- a/contracts/modules/loan/EscrowedLoan.t.sol
+++ b/contracts/modules/loan/EscrowedLoan.t.sol
@@ -1,0 +1,84 @@
+pragma solidity 0.8.9;
+
+import { Escrow } from "../escrow/Escrow.sol";
+import { DSTest } from  "../../../lib/ds-test/src/test.sol";
+import { LoanLib } from "../../utils/LoanLib.sol";
+import { RevenueToken } from "../../mock/RevenueToken.sol";
+import { SimpleOracle } from "../../mock/SimpleOracle.sol";
+import { BasicEscrowedLoan } from "./BasicEscrowedLoan.sol";
+
+contract LoanTest is DSTest {
+
+    Escrow escrow;
+    RevenueToken supportedToken1;
+    RevenueToken supportedToken2;
+    RevenueToken unsupportedToken;
+    SimpleOracle oracle;
+    BasicEscrowedLoan loan;
+    uint mintAmount = 100 ether;
+    uint MAX_INT = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+    uint minCollateralRatio = 1 ether; // 100%
+
+    address borrower;
+    address arbiter;
+    address lender;
+
+    function setUp() public {
+        borrower = address(this);
+        lender = address(this);
+        arbiter = address(this);
+        supportedToken1 = new RevenueToken();
+        supportedToken2 = new RevenueToken();
+        unsupportedToken = new RevenueToken();
+        oracle = new SimpleOracle(address(supportedToken1), address(supportedToken2));
+        loan = new BasicEscrowedLoan(1 ether, address(oracle), arbiter, borrower, address(0), 1 ether);
+        escrow = loan.escrow();
+        _mintAndApprove();
+        escrow.addCollateral(1 ether, address(supportedToken2));
+    }
+
+    function _mintAndApprove() internal {
+        supportedToken1.mint(borrower, mintAmount);
+        supportedToken1.approve(address(escrow), MAX_INT);
+        supportedToken1.approve(address(loan), MAX_INT);
+        supportedToken2.mint(borrower, mintAmount);
+        supportedToken2.approve(address(escrow), MAX_INT);
+        supportedToken2.approve(address(loan), MAX_INT);
+        unsupportedToken.mint(borrower, mintAmount);
+        unsupportedToken.approve(address(escrow), MAX_INT);
+        unsupportedToken.approve(address(loan), MAX_INT);
+    }
+
+    function test_can_liquidate_escrow_if_cratio_below_min() public {
+        loan.addDebtPosition(1 ether, address(supportedToken1), lender);
+        loan.addDebtPosition(1 ether, address(supportedToken1), lender);
+        uint balanceOfEscrow = supportedToken2.balanceOf(address(escrow));
+        uint balanceOfArbiter = supportedToken2.balanceOf(arbiter);
+        bytes32 positionId = loan.positionIds(0);
+        loan.borrow(positionId, 1 ether);
+        assert(loan.principal() > 0);
+        oracle.changePrice(address(supportedToken2), 1);
+        loan.liquidate(positionId, 1 ether, address(supportedToken2));
+        assert(balanceOfEscrow == supportedToken2.balanceOf(address(escrow)) + 1 ether);
+        assert(balanceOfArbiter + 1 ether == supportedToken2.balanceOf(arbiter));
+    }
+
+    function test_health_becomes_liquidatable_if_cratio_below_min() public {
+        assert(loan.healthcheck() == LoanLib.STATUS.ACTIVE);
+        loan.addDebtPosition(1 ether, address(supportedToken1), lender);
+        loan.addDebtPosition(1 ether, address(supportedToken1), lender);
+        bytes32 positionId = loan.positionIds(0);
+        loan.borrow(positionId, 1 ether);
+        oracle.changePrice(address(supportedToken2), 1);
+        assert(loan.healthcheck() == LoanLib.STATUS.LIQUIDATABLE);
+    }
+
+    function testFail_cannot_liquidate_escrow_if_cratio_above_min() public {
+        loan.liquidate(0, 1 ether, address(supportedToken1));
+    }
+
+    function testFail_health_is_not_liquidatable_if_cratio_above_min() public {
+        assert(loan.healthcheck() == LoanLib.STATUS.LIQUIDATABLE);
+    }
+
+}

--- a/contracts/modules/loan/RevolverLoan.sol
+++ b/contracts/modules/loan/RevolverLoan.sol
@@ -3,7 +3,7 @@ import { LoanLib } from "../../utils/LoanLib.sol";
 import { BaseLoan } from "./BaseLoan.sol";
 
 contract RevolverLoan is BaseLoan {
-  bytes32[] positionIds; // all active positions
+  bytes32[] public positionIds; // all active positions
 
   constructor(
     uint256 maxDebtValue_,
@@ -63,7 +63,7 @@ contract RevolverLoan is BaseLoan {
     uint256 len = positionIds.length;
 
     for(uint256 i = 0; i < len; i++) {
-      (, uint256 accruedTokenValue) = _accrueInterest(positionIds[len]);
+      (, uint256 accruedTokenValue) = _accrueInterest(positionIds[i]);
       accruedValue += accruedTokenValue;
     }
 


### PR DESCRIPTION
Closes #43 

This PR:

1. Creates a loan contract that inherits `BaseLoan` & `EscrowedLoan`
2. Performs integration tests between the loan contract and the escrow contract 
3. Removes the bug whereby the contract attempts to use `transferFrom` on its own funds 
4. Makes `BaseLoan._accrueInterest` virtual so that it can be overridden (as this feature is out of scope) 