### PR TITLE
add LoanLib tests 

### DIFF
--- a/contracts/utils/LoanLib.sol
+++ b/contracts/utils/LoanLib.sol
@@ -66,8 +66,6 @@ library LoanLib {
           }
       }
 
-      require(newPositions.length == newLength, "LoanLib: array length mismatch");
-
       return newPositions;
     }
 }

--- a/contracts/utils/LoanLib.sol
+++ b/contracts/utils/LoanLib.sol
@@ -56,19 +56,18 @@ library LoanLib {
      */
     function removePosition(bytes32[] calldata positions, bytes32 id) external view returns(bytes32[] memory) {
       uint256 newLength = positions.length - 1;
-      uint256 count; // index in new positions array to push id next id to
+      uint256 count = 0;
       bytes32[] memory newPositions = new bytes32[](newLength);
 
-      for (uint256 i; i <= newLength;) {
-        if(newPositions[i] == id) continue;
-        newPositions[count] = positions[i];
-        unchecked {
-          ++i;
-          ++count;
-        }
+      for(uint i = 0; i < positions.length; i++) {
+          if(positions[i] != id) {
+              newPositions[count] = positions[i];
+              count++;
+          }
       }
 
-      require(newPositions.length == newLength);
+      require(newPositions.length == newLength, "LoanLib: array length mismatch");
+
       return newPositions;
     }
 }

--- a/contracts/utils/LoanLib.t.sol
+++ b/contracts/utils/LoanLib.t.sol
@@ -1,0 +1,46 @@
+pragma solidity 0.8.9;
+
+import { DSTest } from "../../lib/ds-test/src/test.sol";
+import { LoanLib } from "./LoanLib.sol";
+
+contract LoanLibTest is DSTest {
+
+    address lender = address(0);
+    address loan = address(1);
+    address token = address(2);
+
+    function test_computes_the_same_position_id() public {
+        bytes32 positionId = LoanLib.computePositionId(loan, lender, token);
+        bytes32 positionId2 = LoanLib.computePositionId(loan, lender, token);
+        assert(positionId == positionId2);
+    }
+
+    function test_computes_a_different_position_id() public {
+        bytes32 positionId = LoanLib.computePositionId(loan, lender, token);
+        bytes32 positionId2 = LoanLib.computePositionId(loan, address(this), token);
+        assert(positionId != positionId2);
+        bytes32 positionIdSameInputsDifferentOrder = LoanLib.computePositionId(lender, loan, token);
+        assert(positionIdSameInputsDifferentOrder != positionId);
+    }
+
+    function test_can_remove_position() public {
+        bytes32 positionId = LoanLib.computePositionId(loan, lender, token);
+        bytes32 positionId2 = LoanLib.computePositionId(loan, address(this), token);
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = positionId;
+        ids[1] = positionId2;
+        assert(ids.length == 2);
+        bytes32[] memory newIds = LoanLib.removePosition(ids, positionId2);
+        assert(newIds.length == 1);
+        assert(newIds[0] == positionId);
+    }
+
+    function testFail_cannot_remove_non_existent_position() public {
+        bytes32 positionId = LoanLib.computePositionId(loan, lender, token);
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = positionId;
+        assert(ids.length == 1);
+        LoanLib.removePosition(ids, bytes32(0));
+    }
+
+}


### PR DESCRIPTION
Fixes #61 and addresses LoanLib tests in #18 

@kibagateaux excluded some of the test scenarios included in #18 because they are not required as `abi.encode()` & `keccak256()` are solid and won't be mutated by being called with a different msg.sender or a different block number and the order of inputs is already covered by doing it once (this is technically also not required as the hash output is guaranteed to be different if the order is different) 