### PR TITLE
fix: divide by decimals should divide whole number

### DIFF
--- a/contracts/modules/escrow/Escrow.sol
+++ b/contracts/modules/escrow/Escrow.sol
@@ -79,10 +79,10 @@ contract Escrow is IEscrow {
                 // need to scale value by token decimal
                 (bool success, bytes memory result) = token.call(abi.encodeWithSignature("decimals()"));
                 if(!success) {
-                    collateralValue += price * (deposit / 1e18);
+                    collateralValue += (price * deposit) / 1e18;
                 } else {
                     uint8 decimals = abi.decode(result, (uint8));
-                    collateralValue += price * (deposit / (1 * 10 ** decimals));
+                    collateralValue += (price * deposit) / (1 * 10 ** decimals);
                 }
             }
         }


### PR DESCRIPTION
Dividing by only the amount is dangerous because anything less than the whole decimal unit will return 0. 