### PR TITLE
fix: repay should not be called in close

### DIFF
--- a/contracts/modules/loan/BaseLoan.sol
+++ b/contracts/modules/loan/BaseLoan.sol
@@ -339,7 +339,8 @@ abstract contract BaseLoan is ILoan, MutualUpgrade {
 
   /**
    * @dev - Deletes debt position preventing any more borrowing.
-   *        Only callable by borrower or lender for debt position
+   *      - Only callable by borrower or lender for debt position
+   *      - Requires that the debt has already been paid off
    * @param positionId -the debt position to close
   */
   function close(bytes32 positionId) validPositionId(positionId) override external returns(bool) {
@@ -350,10 +351,9 @@ abstract contract BaseLoan is ILoan, MutualUpgrade {
       "Loan: msg.sender must be the lender or borrower"
     );
     
-    // repay lender initial deposit + accrued interest
+    // return the lender's deposit
     if(debt.deposit > 0) {
       require(IERC20(debt.token).transfer(debt.lender, debt.deposit));
-      _repay(positionId, debt.deposit);
     }
 
     require(_close(positionId));


### PR DESCRIPTION
@kibagateaux it looks like I made a mistake before. Calling `close` assumes that the debt has already been repaid and will revert if it hasn't (on the `_close` call).

This means that #64 is not actually an issue because the debt global vars will have already been updated prior to `close` being called. 

We still need to return the deposit to the `lender` and the debt position should not be blindly cleared (as already solved in #63 but #63 should not call `_repay`). 