### PR TITLE
add eip4626 support 

### DIFF
--- a/contracts/interfaces/IEscrow.sol
+++ b/contracts/interfaces/IEscrow.sol
@@ -8,6 +8,13 @@ interface IEscrow {
         address[] rewardTokens;
     }
 
+    struct Deposit {
+        uint amount;
+        bool isERC4626;
+        address asset; // eip4626 asset else the erc20 token itself
+        uint8 assetDecimals;
+    }
+
     event CollateralAdded(address indexed token, uint amount);
     event CollateralRemoved(address indexed token, uint amount);
     event CollateralFarmed(address indexed token, uint amount);

--- a/contracts/mock/RevenueToken.sol
+++ b/contracts/mock/RevenueToken.sol
@@ -2,10 +2,16 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-
-
 contract RevenueToken is ERC20("Token earned as revenue", "BRRRR") {
-    constructor() {}
+
+    address private _asset;
+    uint private _multiplier;
+
+    constructor() {
+        _asset = address(this);
+        _multiplier = 1;
+    }
+
     function mint(address account, uint256 amount) external returns(bool) {
         _mint(account, amount);
         return true;
@@ -15,5 +21,23 @@ contract RevenueToken is ERC20("Token earned as revenue", "BRRRR") {
     function burnFrom(address account, uint256 amount) external returns(bool) {
         _burn(account, amount);
         return true;
+    }
+
+    function setAssetAddress(address assetAddr) external {
+        _asset = assetAddr;
+    }
+
+    function setAssetMultiplier(uint multiplier) public {
+        _multiplier = multiplier;
+    }
+
+    // mimic eip-4626
+    function asset() public returns(address) {
+        return _asset;
+    }
+
+    // mimic eip-4626
+    function convertToAssets(uint256 amount) public view returns(uint) {
+        return amount * _multiplier;
     }
 }

--- a/contracts/mock/RevenueToken.sol
+++ b/contracts/mock/RevenueToken.sol
@@ -4,40 +4,14 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract RevenueToken is ERC20("Token earned as revenue", "BRRRR") {
 
-    address private _asset;
-    uint private _multiplier;
-
-    constructor() {
-        _asset = address(this);
-        _multiplier = 1;
-    }
-
     function mint(address account, uint256 amount) external returns(bool) {
         _mint(account, amount);
         return true;
     }
-
 
     function burnFrom(address account, uint256 amount) external returns(bool) {
         _burn(account, amount);
         return true;
     }
 
-    function setAssetAddress(address assetAddr) external {
-        _asset = assetAddr;
-    }
-
-    function setAssetMultiplier(uint multiplier) public {
-        _multiplier = multiplier;
-    }
-
-    // mimic eip-4626
-    function asset() public returns(address) {
-        return _asset;
-    }
-
-    // mimic eip-4626
-    function convertToAssets(uint256 amount) public view returns(uint) {
-        return amount * _multiplier;
-    }
 }

--- a/contracts/mock/RevenueToken4626.sol
+++ b/contracts/mock/RevenueToken4626.sol
@@ -1,0 +1,32 @@
+pragma solidity 0.8.9;
+
+import "./RevenueToken.sol";
+
+contract RevenueToken4626 is RevenueToken {
+
+    address private _asset;
+    uint private _multiplier;
+
+    constructor() {
+        _asset = address(this);
+        _multiplier = 1;
+    }
+
+    function setAssetAddress(address assetAddr) external {
+        _asset = assetAddr;
+    }
+
+    function setAssetMultiplier(uint multiplier) public {
+        _multiplier = multiplier;
+    }
+
+    // mimic eip-4626
+    function asset() public returns(address) {
+        return _asset;
+    }
+
+    // mimic eip-4626
+    function previewRedeem(uint256 amount) public view returns(uint) {
+        return amount * _multiplier;
+    }
+}

--- a/contracts/mock/SimpleOracle.sol
+++ b/contracts/mock/SimpleOracle.sol
@@ -23,7 +23,7 @@ contract SimpleOracle is IOracle {
     function getLatestAnswer(address token) external returns(int256) {
         // mimic eip4626
         (bool success, bytes memory result) = token.call(abi.encodeWithSignature("asset()"));
-        if(success) {
+        if(success && result.length > 0) {
             // get the underlying token value (if ERC4626)
             // NB: Share token to underlying ratio might not be 1:1
             token = abi.decode(result, (address));

--- a/contracts/mock/SimpleOracle.sol
+++ b/contracts/mock/SimpleOracle.sol
@@ -5,7 +5,7 @@ import { LoanLib } from "../utils/LoanLib.sol";
 
 contract SimpleOracle is IOracle {
 
-    mapping(address => uint) prices;
+    mapping(address => int) prices;
 
     constructor(address _supportedToken1, address _supportedToken2) {
         prices[_supportedToken1] = 1000 * 1e8; // 1000 USD
@@ -16,11 +16,18 @@ contract SimpleOracle is IOracle {
         return true;
     }
 
-    function changePrice(address token, uint newPrice) external {
+    function changePrice(address token, int newPrice) external {
         prices[token] = newPrice;
     }
 
-    function getLatestAnswer(address token) external returns(uint256) {
+    function getLatestAnswer(address token) external returns(int256) {
+        // mimic eip4626
+        (bool success, bytes memory result) = token.call(abi.encodeWithSignature("asset()"));
+        if(success) {
+            // get the underlying token value (if ERC4626)
+            // NB: Share token to underlying ratio might not be 1:1
+            token = abi.decode(result, (address));
+        }
         require(prices[token] != 0, "SimpleOracle: unsupported token");
         return prices[token];
     }

--- a/contracts/modules/escrow/Escrow.sol
+++ b/contracts/modules/escrow/Escrow.sol
@@ -25,7 +25,7 @@ contract Escrow is IEscrow {
     mapping(address => bool) private _tokensUsed;
 
     // tokens used as collateral (must be able to value with oracle)
-    mapping(address => uint) public deposited;
+    mapping(address => Deposit) public deposited;
 
     // collateral tokens that have been used for farming
     mapping(address => Farm) public farmedTokens;
@@ -73,27 +73,18 @@ contract Escrow is IEscrow {
         uint collateralValue = 0;
         for(uint i = 0; i < _tokensUsedAsCollateral.length; i++) {
             address token = _tokensUsedAsCollateral[i];
-            uint deposit = deposited[token];
+            uint deposit = deposited[token].amount;
             if(deposit != 0) {
-                (bool success, bytes memory assetAmount) = token.call(abi.encodeWithSignature("convertToAssets(uint256)", deposit));
-                if(success) {
-                    // this is an eip4626 token, adjust the amount to the underlying
+                if(deposited[token].isERC4626) {
+                    // this conversion could shift, hence it is best to get it each time
+                    (bool success, bytes memory assetAmount) = token.call(abi.encodeWithSignature("previewRedeem(uint256)", deposit));
                     deposit = abi.decode(assetAmount, (uint));
-                    (bool passed, bytes memory tokenAddrBytes) = token.call(abi.encodeWithSignature("asset()"));
-                    // we need this because the decimals between the share token and underlying could differ
-                    token = abi.decode(tokenAddrBytes, (address));
                 }
                 int prc = IOracle(oracle).getLatestAnswer(token);
                 // treat negative prices as 0
                 uint price = prc < 0 ? 0 : uint(prc);
                 // need to scale value by token decimal
-                (bool successDecimals, bytes memory result) = token.call(abi.encodeWithSignature("decimals()"));
-                if(!successDecimals) {
-                    collateralValue += (price * deposit) / 1e18;
-                } else {
-                    uint8 decimals = abi.decode(result, (uint8));
-                    collateralValue += (price * deposit) / (1 * 10 ** decimals);
-                }
+                collateralValue += (price * deposit) / (1 * 10 ** deposited[token].assetDecimals);
             }
         }
 
@@ -110,7 +101,7 @@ contract Escrow is IEscrow {
             "Escrow: deposited token does not have a price feed"
         );
         require(IERC20(token).transferFrom(msg.sender, address(this), amount));
-        deposited[token] += amount;
+        deposited[token].amount += amount;
         _addTokenUsed(token);
         emit CollateralAdded(token, amount);
 
@@ -124,6 +115,20 @@ contract Escrow is IEscrow {
         if(!_tokensUsed[token]) {
             _tokensUsed[token] = true;
             _tokensUsedAsCollateral.push(token);
+            (bool passed, bytes memory tokenAddrBytes) = token.call(abi.encodeWithSignature("asset()"));
+            bool is4626 = tokenAddrBytes.length > 0 && passed;
+            deposited[token].isERC4626 = is4626;
+            if(is4626) {
+                deposited[token].asset = abi.decode(tokenAddrBytes, (address));
+            } else {
+                deposited[token].asset = token;
+            }
+            (bool successDecimals, bytes memory decimalBytes) = deposited[token].asset.call(abi.encodeWithSignature("decimals()"));
+            if(decimalBytes.length > 0 && successDecimals) {
+                deposited[token].assetDecimals = abi.decode(decimalBytes, (uint8));
+            } else {
+                deposited[token].assetDecimals = 18;
+            }
         }
     }
 
@@ -133,8 +138,8 @@ contract Escrow is IEscrow {
     function releaseCollateral(uint amount, address token, address to) external returns(uint) {
         require(amount > 0, "Escrow: amount is 0");
         require(msg.sender == borrower, "Escrow: only borrower can call");
-        require(deposited[token] >= amount, "Escrow: insufficient balance");
-        deposited[token] -= amount;
+        require(deposited[token].amount >= amount, "Escrow: insufficient balance");
+        deposited[token].amount -= amount;
         require(IERC20(token).transfer(to, amount));
         uint cratio = _getLatestCollateralRatio();
         require(cratio >= minimumCollateralRatio, "Escrow: cannot release collateral if cratio becomes lower than the minimum");
@@ -164,8 +169,8 @@ contract Escrow is IEscrow {
         require(amount > 0, "Escrow: amount is 0");
         require(msg.sender == loan, "Escrow: msg.sender must be the loan contract");
         require(minimumCollateralRatio > _getLatestCollateralRatio(), "Escrow: not eligible for liquidation");
-        require(deposited[token] >= amount, "Escrow: insufficient balance");
-        deposited[token] -= amount;
+        require(deposited[token].amount >= amount, "Escrow: insufficient balance");
+        deposited[token].amount -= amount;
         require(IERC20(token).transfer(to, amount));
         emit Liquidated(token, amount);
 

--- a/contracts/modules/escrow/Escrow.t.sol
+++ b/contracts/modules/escrow/Escrow.t.sol
@@ -4,6 +4,7 @@ import { Escrow } from "./Escrow.sol";
 import { DSTest } from  "../../../lib/ds-test/src/test.sol";
 import { LoanLib } from "../../utils/LoanLib.sol";
 import { RevenueToken } from "../../mock/RevenueToken.sol";
+import { RevenueToken4626 } from "../../mock/RevenueToken4626.sol";
 import { SimpleOracle } from "../../mock/SimpleOracle.sol";
 import { MockLoan } from "../../mock/MockLoan.sol";
 
@@ -13,6 +14,7 @@ contract EscrowTest is DSTest {
     RevenueToken supportedToken1;
     RevenueToken supportedToken2;
     RevenueToken unsupportedToken;
+    RevenueToken4626 token4626;
     SimpleOracle oracle;
     MockLoan loan;
     uint mintAmount = 100 ether;
@@ -27,6 +29,7 @@ contract EscrowTest is DSTest {
         supportedToken1 = new RevenueToken();
         supportedToken2 = new RevenueToken();
         unsupportedToken = new RevenueToken();
+        token4626 = new RevenueToken4626();
         oracle = new SimpleOracle(address(supportedToken1), address(supportedToken2));
         loan = new MockLoan(1);
         _createEscrow(minCollateralRatio, address(oracle), address(loan), borrower);
@@ -41,6 +44,8 @@ contract EscrowTest is DSTest {
         supportedToken2.approve(address(escrow), MAX_INT);
         unsupportedToken.mint(borrower, mintAmount);
         unsupportedToken.approve(address(escrow), MAX_INT);
+        token4626.mint(borrower, mintAmount);
+        token4626.approve(address(escrow), MAX_INT);
     }
 
     function _createEscrow(
@@ -60,6 +65,13 @@ contract EscrowTest is DSTest {
         assertEq(collateralValue, (1000 * 1e8) * (mintAmount / 1 ether), "collateral value should equal the mint amount * price");
     }
 
+    function test_can_get_correct_collateral_value_eip4626() public {
+        token4626.setAssetAddress(address(supportedToken1));
+        escrow.addCollateral(mintAmount, address(token4626));
+        uint collateralValue = escrow.getCollateralValue();
+        assertEq(collateralValue, (1000 * 1e8) * (mintAmount / 1 ether), "collateral value should equal the mint amount * price");
+    }
+
     function test_can_add_collateral() public {
         uint borrowerBalance = supportedToken1.balanceOf(borrower);
         escrow.addCollateral(mintAmount, address(supportedToken1));
@@ -69,21 +81,19 @@ contract EscrowTest is DSTest {
         assertEq(borrowerBalance2, supportedToken2.balanceOf(borrower) + mintAmount, "borrower should have decreased with collateral deposit");
     }
 
-    function test_can_add_collateral_eip4626_mimic() public {
-        uint borrowerBalance = supportedToken1.balanceOf(borrower);
-        supportedToken1.setAssetAddress(address(supportedToken2));
-        supportedToken1.setAssetMultiplier(5);
-        escrow.addCollateral(mintAmount, address(supportedToken1));
-        assertEq(borrowerBalance, supportedToken1.balanceOf(borrower) + mintAmount, "borrower balance should have been reduced by mintAmount");
+    function test_can_add_collateral_eip4626() public {
+        uint borrowerBalance = token4626.balanceOf(borrower);
+        token4626.setAssetAddress(address(supportedToken2));
+        escrow.addCollateral(mintAmount, address(token4626));
+        assertEq(borrowerBalance, token4626.balanceOf(borrower) + mintAmount, "borrower balance should have been reduced by mintAmount");
     }
 
-    function test_can_remove_collateral_eip4626_mimic() public {
-        uint borrowerBalance = supportedToken1.balanceOf(borrower);
-        supportedToken1.setAssetAddress(address(supportedToken2));
-        supportedToken1.setAssetMultiplier(5);
-        escrow.addCollateral(mintAmount, address(supportedToken1));
-        escrow.releaseCollateral(1 ether, address(supportedToken1), borrower);
-        assertEq(1 ether, supportedToken1.balanceOf(borrower), "should have returned collateral");
+    function test_can_remove_collateral_eip4626() public {
+        uint borrowerBalance = token4626.balanceOf(borrower);
+        token4626.setAssetAddress(address(supportedToken2));
+        escrow.addCollateral(mintAmount, address(token4626));
+        escrow.releaseCollateral(1 ether, address(token4626), borrower);
+        assertEq(1 ether, token4626.balanceOf(borrower), "should have returned collateral");
     }
 
     function test_can_remove_collateral() public {
@@ -112,6 +122,16 @@ contract EscrowTest is DSTest {
         assertEq(newEscrowRatio, escrowRatio * 10, "new cratio should be 10x the original");
     }
 
+    function test_cratio_adjusts_when_collateral_price_changes_eip4626() public {
+        token4626.setAssetAddress(address(supportedToken1));
+        escrow.addCollateral(1 ether, address(token4626));
+        loan.setDebtValue(1000);
+        uint escrowRatio = escrow.getCollateralRatio();
+        oracle.changePrice(address(supportedToken1), 10000 * 1e8);
+        uint newEscrowRatio = escrow.getCollateralRatio();
+        assertEq(newEscrowRatio, escrowRatio * 10, "new cratio should be 10x the original");
+    }
+
     function test_can_liquidate() public {
         escrow.addCollateral(1 ether, address(supportedToken1));
         escrow.addCollateral(0.9 ether, address(supportedToken2));
@@ -123,19 +143,14 @@ contract EscrowTest is DSTest {
         assertEq(supportedToken2.balanceOf(arbiter), 0.9 ether, "arbiter should have received token 2");
     }
 
-    function test_can_liquidate_eip4626_mimic() public {
-        supportedToken1.setAssetAddress(address(supportedToken2));
-        supportedToken1.setAssetMultiplier(5);
-        supportedToken2.setAssetAddress(address(supportedToken1));
-        supportedToken2.setAssetMultiplier(10);
-        escrow.addCollateral(1 ether, address(supportedToken1));
-        escrow.addCollateral(0.9 ether, address(supportedToken2));
+    function test_can_liquidate_eip4626() public {
+        token4626.setAssetAddress(address(supportedToken1));
+        token4626.setAssetMultiplier(5);
+        escrow.addCollateral(1 ether, address(token4626));
         loan.setDebtValue(2000 ether);
         assertGt(minCollateralRatio, escrow.getCollateralRatio(), "should be below the liquidation threshold");
-        loan.liquidate(0, 1 ether, address(supportedToken1), arbiter);
-        loan.liquidate(0, 0.9 ether, address(supportedToken2), arbiter);
-        assertEq(supportedToken1.balanceOf(arbiter), 1 ether, "arbiter should have received token 1");
-        assertEq(supportedToken2.balanceOf(arbiter), 0.9 ether, "arbiter should have received token 2");
+        loan.liquidate(0, 1 ether, address(token4626), arbiter);
+        assertEq(token4626.balanceOf(arbiter), 1 ether, "arbiter should have received 1e18 worth of the 4626 token");
     }
 
     function test_cratio_should_be_max_int_if_no_debt() public {
@@ -161,10 +176,10 @@ contract EscrowTest is DSTest {
         assertEq(escrow.getCollateralRatio(), 0, "cratio should be 0");
     }
 
-    function test_cratio_values_with_eip4626_mimic() public {
-        supportedToken1.setAssetAddress(address(supportedToken2));
-        supportedToken1.setAssetMultiplier(2); // share token should be worth double the underlying (which is now supportedToken2)
-        escrow.addCollateral(1 ether, address(supportedToken1));
+    function test_cratio_values_with_eip4626() public {
+        token4626.setAssetAddress(address(supportedToken2));
+        token4626.setAssetMultiplier(2); // share token should be worth double the underlying (which is now supportedToken2)
+        escrow.addCollateral(1 ether, address(token4626));
         loan.setDebtValue(4000 * 1e8); // 1e18 of supportedToken2 * 2 == 4000 * 1e8 (4000 USD)
         assertEq(escrow.getCollateralRatio(), 1 ether, "cratio should be 100%");
         loan.setDebtValue(10 * (4000 * 1e8)); // 10x the collateral value (40000 USD)
@@ -181,18 +196,30 @@ contract EscrowTest is DSTest {
         escrow.releaseCollateral(1 ether, address(supportedToken1), borrower);
     }
 
+    function testFail_cannot_remove_collateral_when_under_collateralized_eip4626() public {
+        token4626.setAssetAddress(address(supportedToken1));
+        escrow.addCollateral(1 ether, address(token4626));
+        loan.setDebtValue(2000 ether);
+        escrow.releaseCollateral(1 ether, address(token4626), borrower);
+    }
+
     function testFail_cannot_liquidate_when_loan_healthy() public {
         escrow.addCollateral(1 ether, address(supportedToken1));
         loan.liquidate(0, 1 ether, address(supportedToken1), arbiter);
+    }
+
+    function testFail_cannot_liquidate_when_loan_healthy_eip4626() public {
+        token4626.setAssetAddress(address(supportedToken1));
+        escrow.addCollateral(1 ether, address(token4626));
+        loan.liquidate(0, 1 ether, address(token4626), arbiter);
     }
 
     function testFail_cannot_add_collateral_if_unsupported_by_oracle() public {
         escrow.addCollateral(1000, address(unsupportedToken));
     }
 
-    function testFail_cannot_add_collateral_if_unsupported_by_oracle_eip4626_mimic() public {
-        supportedToken1.setAssetAddress(address(unsupportedToken));
-        supportedToken1.setAssetMultiplier(2);
-        escrow.addCollateral(1000, address(supportedToken1));
+    function testFail_cannot_add_collateral_if_unsupported_by_oracle_eip4626() public {
+        token4626.setAssetAddress(address(unsupportedToken));
+        escrow.addCollateral(1000, address(token4626));
     }
 }

--- a/contracts/modules/loan/BaseLoan.sol
+++ b/contracts/modules/loan/BaseLoan.sol
@@ -447,6 +447,8 @@ abstract contract BaseLoan is ILoan, MutualUpgrade {
    * @param token - token to get price for
   */
   function _getTokenPrice(address token) internal returns (uint256) {
-    return IOracle(oracle).getLatestAnswer(token);
+    int prc = IOracle(oracle).getLatestAnswer(token);
+    // treat negative prices as 0
+    return prc < 0 ? 0 : uint(prc);
   }
 }

--- a/contracts/modules/oracle/Oracle.sol
+++ b/contracts/modules/oracle/Oracle.sol
@@ -15,7 +15,13 @@ contract Oracle is IOracle {
     /**
      * Returns the latest price in USD
      */
-    function getLatestAnswer(address token) external view returns (int) {
+    function getLatestAnswer(address token) external returns (int) {
+        (bool success, bytes memory result) = token.call(abi.encodeWithSignature("asset()"));
+        if(success) {
+            // get the underlying token value (if ERC4626)
+            // NB: Share token to underlying ratio might not be 1:1
+            token = abi.decode(result, (address));
+        }
         (
             /* uint80 roundID */, 
             int price,

--- a/contracts/modules/oracle/Oracle.sol
+++ b/contracts/modules/oracle/Oracle.sol
@@ -17,7 +17,7 @@ contract Oracle is IOracle {
      */
     function getLatestAnswer(address token) external returns (int) {
         (bool success, bytes memory result) = token.call(abi.encodeWithSignature("asset()"));
-        if(success) {
+        if(success && result.length > 0) {
             // get the underlying token value (if ERC4626)
             // NB: Share token to underlying ratio might not be 1:1
             token = abi.decode(result, (address));

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,11 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@chainlink/contracts": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.4.1.tgz",
+      "integrity": "sha512-eC8biY6Ks8k9kZKVt5305veCP3z57yyiy6Os5aR6auta6Bp34xWQ/s4qvrifcW4FNgWw1HJPwMPXDGfiehcLjg=="
+    },
     "@ensdomains/ens": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.4.5.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "hardhat-deploy": "^0.9.23"
   },
   "dependencies": {
+    "@chainlink/contracts": "^0.4.1",
     "@openzeppelin/contracts": "^4.5.0"
   },
   "scripts": {


### PR DESCRIPTION
Closes #78 

This PR:
1. Adds eip4626 support (see #78)
2. Fixes compilation errors caused by recent commits 
3. Replaces old asserts (in `Escrow.t.sol`) with more meaningful methods i.e. `assertEq` & `assertGt`
4. Refactors the escrow collateral logic 