### PR TITLE
Halborn fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+on: [push]
+
+name: test
+
+jobs:
+  yarn-install:
+    runs-on: ubuntu-latest
+    name: Foundry Tests
+    steps:
+      - uses: actions/checkout@v2     # foundry docs say v3 but npm install uses v2
+        with:
+          submodules: recursive       # ensure forge-std installed
+      - uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: true
+        env:
+          NODE_ENV: development       # install all test tooling 
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run tests
+        run: forge test -vvv          # output traces for failing tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/ds-test"]
 	path = lib/ds-test
 	url = https://github.com/dapphub/ds-test
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/contracts/interfaces/IEscrow.sol
+++ b/contracts/interfaces/IEscrow.sol
@@ -12,7 +12,7 @@ interface IEscrow {
 
     event RemoveCollateral(address indexed token, uint indexed amount);
 
-    event EnableCollateral(address indexed token, int indexed price);
+    event EnableCollateral(address indexed token);
     
     event Liquidate(address indexed token, uint indexed amount);
 

--- a/contracts/interfaces/IEscrowedLoan.sol
+++ b/contracts/interfaces/IEscrowedLoan.sol
@@ -3,5 +3,5 @@ pragma solidity 0.8.9;
 interface IEscrowedLoan {
   event Liquidate(bytes32 indexed positionId, uint256 indexed amount, address indexed token);
 
-  function liquidate(bytes32 positionId, uint256 amount, address targetToken) external returns(uint256);
+  function liquidate(uint256 amount, address targetToken) external returns(uint256);
 }

--- a/contracts/interfaces/ILineOfCredit.sol
+++ b/contracts/interfaces/ILineOfCredit.sol
@@ -43,7 +43,7 @@ interface ILineOfCredit is ILoan {
     uint256 amount,
     address token,
     address lender
-  ) external returns(bytes32);
+  ) external payable returns(bytes32);
 
   function setRates(
     bytes32 id,
@@ -54,8 +54,8 @@ interface ILineOfCredit is ILoan {
   function increaseCredit(
     bytes32 id,
     uint256 amount
-  ) external returns(bool);
+  ) external payable returns(bool);
 
   function borrow(bytes32 id, uint256 amount) external returns(bool);
-  function close(bytes32 id) external returns(bool);
+  function close(bytes32 id) external payable returns(bool);
 }

--- a/contracts/interfaces/ILineOfCredit.sol
+++ b/contracts/interfaces/ILineOfCredit.sol
@@ -32,6 +32,8 @@ interface ILineOfCredit is ILoan {
   error NoLiquidity();
   error PositionExists();
   error CloseFailedWithPrincipal();
+  error NotInsolvent(address module);
+  error NotLiquidatable();
 
   function updateOutstandingDebt() external returns(uint256, uint256);
 

--- a/contracts/interfaces/ILoan.sol
+++ b/contracts/interfaces/ILoan.sol
@@ -63,6 +63,7 @@ interface ILoan {
   function accrueInterest() external returns(bool);
   function updateOutstandingDebt() external returns(uint256, uint256);
   function healthcheck() external returns(LoanLib.STATUS);
+  function declareInsolvent() external returns(bool);
 
   function borrower() external returns(address);
   function arbiter() external returns(address);

--- a/contracts/interfaces/ILoan.sol
+++ b/contracts/interfaces/ILoan.sol
@@ -57,8 +57,8 @@ interface ILoan {
   // External Functions  
   function withdraw(bytes32 id, uint256 amount) external returns(bool);
 
-  function depositAndRepay(uint256 amount) external returns(bool);
-  function depositAndClose() external returns(bool);
+  function depositAndRepay(uint256 amount) external payable returns(bool);
+  function depositAndClose() external payable returns(bool);
 
   function accrueInterest() external returns(bool);
   function updateOutstandingDebt() external returns(uint256, uint256);

--- a/contracts/interfaces/ILoan.sol
+++ b/contracts/interfaces/ILoan.sol
@@ -66,5 +66,6 @@ interface ILoan {
 
   function borrower() external returns(address);
   function arbiter() external returns(address);
+  function loanStatus() external returns(LoanLib.STATUS);
   function oracle() external returns(IOracle);
 }

--- a/contracts/interfaces/ISpigot.sol
+++ b/contracts/interfaces/ISpigot.sol
@@ -40,4 +40,7 @@ interface ISpigot {
     
     error BadSetting();
 
+    function isWhitelisted(bytes4 func) external view returns(bool);
+    function getEscrowed(address token) external view returns(uint256);
+
 }

--- a/contracts/interfaces/ISpigot.sol
+++ b/contracts/interfaces/ISpigot.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.8.9;
+
 interface ISpigot {
 
     struct Setting {
@@ -35,6 +37,8 @@ interface ISpigot {
     error ClaimFailed();
 
     error NoRevenue();
+
+    error UnclaimedRevenue();
 
     error CallerAccessDenied();
     

--- a/contracts/interfaces/ISpigotedLoan.sol
+++ b/contracts/interfaces/ISpigotedLoan.sol
@@ -37,5 +37,5 @@ interface ISpigotedLoan {
     bytes calldata zeroExTradeData
   ) external returns(bool);
 
-  function sweep(address token) external returns(uint256);
+  function sweep(address to, address token) external returns(uint256);
 }

--- a/contracts/mock/MockLoan.sol
+++ b/contracts/mock/MockLoan.sol
@@ -1,17 +1,20 @@
 pragma solidity 0.8.9;
 
 import { IEscrow } from "../interfaces/IEscrow.sol";
+import { LoanLib } from "../utils/LoanLib.sol";
 
 contract MockLoan {
 
     uint debtValueUSD;
     address escrow;
     address public arbiter;
+    LoanLib.STATUS public loanStatus;
 
     constructor(uint _debt, address arbiter_) public {
         debtValueUSD = _debt;
         // console.log("arbiter", msg.sender);
         arbiter = arbiter_;
+        loanStatus =  LoanLib.STATUS.ACTIVE;
     }
 
     function setEscrow(address _escrow) public {
@@ -25,6 +28,11 @@ contract MockLoan {
 
     function setDebtValue(uint _debt) external {
         debtValueUSD = _debt;
+    }
+
+
+    function setStatus(LoanLib.STATUS _status) external {
+        loanStatus = _status;
     }
 
     function liquidate(uint positionId, uint amount, address token, address to) external {

--- a/contracts/mock/MockLoan.sol
+++ b/contracts/mock/MockLoan.sol
@@ -8,10 +8,10 @@ contract MockLoan {
     address escrow;
     address public arbiter;
 
-    constructor(uint _debt) public {
+    constructor(uint _debt, address arbiter_) public {
         debtValueUSD = _debt;
         // console.log("arbiter", msg.sender);
-        arbiter = msg.sender;
+        arbiter = arbiter_;
     }
 
     function setEscrow(address _escrow) public {
@@ -28,6 +28,7 @@ contract MockLoan {
     }
 
     function liquidate(uint positionId, uint amount, address token, address to) external {
+        require(msg.sender == arbiter);
         IEscrow(escrow).liquidate(amount, token, to);
     }
 

--- a/contracts/mock/SimpleOracle.sol
+++ b/contracts/mock/SimpleOracle.sol
@@ -1,5 +1,6 @@
 pragma solidity 0.8.9;
 
+import { Denominations } from "@chainlink/contracts/src/v0.8/Denominations.sol";
 import { IOracle } from "../interfaces/IOracle.sol";
 import { LoanLib } from "../utils/LoanLib.sol";
 
@@ -10,6 +11,7 @@ contract SimpleOracle is IOracle {
     constructor(address _supportedToken1, address _supportedToken2) {
         prices[_supportedToken1] = 1000 * 1e8; // 1000 USD
         prices[_supportedToken2] = 2000 * 1e8; // 2000 USD
+        prices[Denominations.ETH] = 2000 * 1e8; // 2000 USD
     }
 
     function init() external returns(bool) {
@@ -21,13 +23,6 @@ contract SimpleOracle is IOracle {
     }
 
     function getLatestAnswer(address token) external returns(int256) {
-        // mimic eip4626
-        // (bool success, bytes memory result) = token.call(abi.encodeWithSignature("asset()"));
-        // if(success && result.length > 0) {
-        //     // get the underlying token value (if ERC4626)
-        //     // NB: Share token to underlying ratio might not be 1:1
-        //     token = abi.decode(result, (address));
-        // }
         require(prices[token] != 0, "SimpleOracle: unsupported token");
         return prices[token];
     }

--- a/contracts/mock/SimpleRevenueContract.sol
+++ b/contracts/mock/SimpleRevenueContract.sol
@@ -1,4 +1,5 @@
 pragma solidity 0.8.9;
+import { Denominations } from "@chainlink/contracts/src/v0.8/Denominations.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract SimpleRevenueContract {
@@ -12,7 +13,7 @@ contract SimpleRevenueContract {
 
     function claimPullPayment() external returns(bool) {
         require(msg.sender == owner, "Revenue: Only owner can claim");
-        if(address(revenueToken) != address(0)) {
+        if(address(revenueToken) != Denominations.ETH) {
             require(revenueToken.transfer(owner, revenueToken.balanceOf(address(this))), "Revenue: bad transfer");
         } else {
             payable(owner).transfer(address(this).balance);
@@ -21,7 +22,7 @@ contract SimpleRevenueContract {
     }
 
     function sendPushPayment() external returns(bool) {
-        if(address(revenueToken) != address(0)) {
+        if(address(revenueToken) != Denominations.ETH) {
             require(revenueToken.transfer(owner, revenueToken.balanceOf(address(this))), "Revenue: bad transfer");
         } else {
             payable(owner).transfer(address(this).balance);

--- a/contracts/mock/ZeroEx.sol
+++ b/contracts/mock/ZeroEx.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.8.9;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { LoanLib } from "../utils/LoanLib.sol";
 
 contract ZeroEx {
   constructor () {
@@ -15,10 +16,11 @@ contract ZeroEx {
     uint256 minAmountOut
   )
     external
+    payable
     returns(bool)
   {
-    require(IERC20(tokenIn).transferFrom(msg.sender, address(this), amountIn));
-    require(IERC20(tokenOut).transfer(msg.sender, minAmountOut));
+    LoanLib.receiveTokenOrETH(tokenIn, msg.sender, amountIn);
+    LoanLib.sendOutTokenOrETH(tokenOut, msg.sender, minAmountOut);
     return true;
   }
 }

--- a/contracts/modules/credit/EscrowedLoan.sol
+++ b/contracts/modules/credit/EscrowedLoan.sol
@@ -62,7 +62,7 @@ abstract contract EscrowedLoan is IEscrowedLoan, ILineOfCredit {
    *(@dev priviliegad internal function.
    * @return if loan is insolvent or not
   */
-  function _declareInsolvent() internal virtual returns(bool) {
+  function _canDeclareInsolvent() internal virtual returns(bool) {
     if(escrow.getCollateralValue() != 0) { revert NotInsolvent(address(escrow)); }
     return true;
   }

--- a/contracts/modules/credit/EscrowedLoan.sol
+++ b/contracts/modules/credit/EscrowedLoan.sol
@@ -3,8 +3,9 @@ pragma solidity 0.8.9;
 import { Escrow } from "../escrow/Escrow.sol";
 import { LoanLib } from "../../utils/LoanLib.sol";
 import { IEscrowedLoan } from "../../interfaces/IEscrowedLoan.sol";
+import { ILineOfCredit } from "../../interfaces/ILineOfCredit.sol";
 
-abstract contract EscrowedLoan is IEscrowedLoan {
+abstract contract EscrowedLoan is IEscrowedLoan, ILineOfCredit {
   // contract holding all collateral for borrower
   Escrow immutable public escrow;
 
@@ -39,7 +40,6 @@ abstract contract EscrowedLoan is IEscrowedLoan {
    * @param to - the liquidator to send tokens to. could be OTC address or smart contract
    * @return amount - the total amount of `targetToken` sold to repay credit
    *  
-   
   */
   function _liquidate(
     bytes32 positionId,
@@ -55,6 +55,16 @@ abstract contract EscrowedLoan is IEscrowedLoan {
     emit Liquidate(positionId, amount, targetToken);
 
     return amount;
+  }
+
+  /**
+   * @notice require all collateral sold off before declaring insolvent
+   *(@dev priviliegad internal function.
+   * @return if loan is insolvent or not
+  */
+  function _declareInsolvent() internal virtual returns(bool) {
+    if(escrow.getCollateralValue() != 0) { revert NotInsolvent(address(escrow)); }
+    return true;
   }
 }
 

--- a/contracts/modules/credit/LineOfCredit.sol
+++ b/contracts/modules/credit/LineOfCredit.sol
@@ -119,10 +119,7 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
             revert NotLiquidatable();
         }
 
-      // TODO for cwalk. Should we ensure only insolvent once ttl is over? 
-      // Possible borrower fail anytime. no reson to prevent impairment until deadline
-
-        if(_declareInsolvent()) {
+        if(_canDeclareInsolvent()) {
             _updateLoanStatus(LoanLib.STATUS.INSOLVENT);
             return true;
         } else {
@@ -130,7 +127,7 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
         }
     }
 
-    function _declareInsolvent() internal virtual returns(bool) {
+    function _canDeclareInsolvent() internal virtual returns(bool) {
         return true;
     }
 

--- a/contracts/modules/credit/LineOfCredit.sol
+++ b/contracts/modules/credit/LineOfCredit.sol
@@ -113,7 +113,7 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
      *           Callable only by arbiter. 
      * @return bool - If borrower is insolvent or not
      */
-    function declareInsolvent() external returns(bool) {
+    function declareInsolvent() external whileBorrowing returns(bool) {
         if(arbiter != msg.sender) { revert CallerAccessDenied(); }
         if(LoanLib.STATUS.LIQUIDATABLE != _updateLoanStatus(_healthcheck())) {
             revert NotLiquidatable();

--- a/contracts/modules/credit/LineOfCredit.sol
+++ b/contracts/modules/credit/LineOfCredit.sol
@@ -400,7 +400,7 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
         // ensure all money owed is accounted for
         _accrueInterest(id);
         uint256 facilityFee = credits[id].interestAccrued;
-        if(facilityFee != 0) {
+        if(facilityFee > 0) {
           // only allow repaying interest since they are skipping repayment queue.
           // If principal still owed, _close() MUST fail
           IERC20( credits[id].token).safeTransferFrom(b, address(this), facilityFee);

--- a/contracts/modules/credit/SecuredLoan.sol
+++ b/contracts/modules/credit/SecuredLoan.sol
@@ -67,4 +67,18 @@ contract SecuredLoan is SpigotedLoan, EscrowedLoan {
       return EscrowedLoan._healthcheck();
     }
 
+
+    /// @notice all insolvency conditions must pass for call to succeed
+    function _declareInsolvent()
+      internal
+      virtual
+      override(EscrowedLoan, SpigotedLoan)
+      returns(bool)
+    {
+      return (
+        EscrowedLoan._declareInsolvent() &&
+        SpigotedLoan._declareInsolvent()
+      );
+    }
+
 }

--- a/contracts/modules/credit/SecuredLoan.sol
+++ b/contracts/modules/credit/SecuredLoan.sol
@@ -70,15 +70,15 @@ contract SecuredLoan is SpigotedLoan, EscrowedLoan {
 
 
     /// @notice all insolvency conditions must pass for call to succeed
-    function _declareInsolvent()
+    function _canDeclareInsolvent()
       internal
       virtual
       override(EscrowedLoan, SpigotedLoan)
       returns(bool)
     {
       return (
-        EscrowedLoan._declareInsolvent() &&
-        SpigotedLoan._declareInsolvent()
+        EscrowedLoan._canDeclareInsolvent() &&
+        SpigotedLoan._canDeclareInsolvent()
       );
     }
 

--- a/contracts/modules/credit/SecuredLoan.sol
+++ b/contracts/modules/credit/SecuredLoan.sol
@@ -37,24 +37,25 @@ contract SecuredLoan is SpigotedLoan, EscrowedLoan {
    * @dev - only called by neutral arbiter party/contract
    * @dev - `loanStatus` must be LIQUIDATABLE
    * @dev - callable by `arbiter`
-   * @param positionId -the debt position to pay down debt on
    * @param amount - amount of `targetToken` expected to be sold off in  _liquidate
    * @param targetToken - token in escrow that will be sold of to repay position
    */
 
   function liquidate(
-    bytes32 positionId,
     uint256 amount,
     address targetToken
   )
     external
+    whileBorrowing
     returns(uint256)
   {
-    require(msg.sender == arbiter);
-    require(_updateLoanStatus(_healthcheck()) == LoanLib.STATUS.LIQUIDATABLE);
+    if(msg.sender != arbiter) { revert CallerAccessDenied(); }
+    if(_updateLoanStatus(_healthcheck()) != LoanLib.STATUS.LIQUIDATABLE) {
+      revert NotLiquidatable();
+    }
 
     // send tokens to arbiter for OTC sales
-    return _liquidate(positionId, amount, targetToken, msg.sender);
+    return _liquidate(ids[0], amount, targetToken, msg.sender);
   }
   
     /** @notice checks internal accounting logic for status and if ok, runs modules checks */

--- a/contracts/modules/credit/SecuredLoan.t.sol
+++ b/contracts/modules/credit/SecuredLoan.t.sol
@@ -695,6 +695,9 @@ contract LoanTest is Test {
 
         // ensure spigot insolvency check passes
         assertTrue(loan.releaseSpigot());
+        // "sell" spigot off
+        loan.spigot().updateOwner(address(0xf1c0));
+
         assertEq(0.9 ether, loan.liquidate(0.9 ether, address(supportedToken2)));
 
         vm.expectRevert(
@@ -728,6 +731,7 @@ contract LoanTest is Test {
         hoax(arbiter);
 
         assertTrue(loan.releaseSpigot());
+        assertTrue(loan.spigot().updateOwner(address(0xf1c0)));
         assertEq(1 ether, loan.liquidate(1 ether, address(supportedToken2)));
         // release spigot + liquidate
         loan.declareInsolvent();

--- a/contracts/modules/credit/SecuredLoan.t.sol
+++ b/contracts/modules/credit/SecuredLoan.t.sol
@@ -1,13 +1,13 @@
 pragma solidity 0.8.9;
 
 import { Escrow } from "../escrow/Escrow.sol";
-import { DSTest } from  "../../../lib/ds-test/src/test.sol";
+import { Test } from "forge-std/Test.sol";
 import { LoanLib } from "../../utils/LoanLib.sol";
 import { RevenueToken } from "../../mock/RevenueToken.sol";
 import { SimpleOracle } from "../../mock/SimpleOracle.sol";
 import { SecuredLoan } from "./SecuredLoan.sol";
 
-contract LoanTest is DSTest {
+contract LoanTest is Test {
 
     Escrow escrow;
     RevenueToken supportedToken1;

--- a/contracts/modules/credit/SpigotedLoan.sol
+++ b/contracts/modules/credit/SpigotedLoan.sol
@@ -54,6 +54,14 @@ contract SpigotedLoan is ISpigotedLoan, LineOfCredit {
         return unusedTokens[token];
     }
 
+    function _declareInsolvent() internal virtual override returns(bool) {
+      // Must have called releaseSpigot() and sold off protocol / revenue streams already
+      if(address(this) == spigot.owner()) { revert NotInsolvent(address(spigot)); }
+      // no additional logic in LineOfCredit to include
+      return true;
+    }
+
+
     /**
 
    * @notice - Claims revenue tokens from Spigot attached to borrowers revenue generating tokens
@@ -267,7 +275,7 @@ contract SpigotedLoan is ISpigotedLoan, LineOfCredit {
         if (s == LoanLib.STATUS.REPAID) {
             return _sweep(borrower, token);
         }
-        if (s == LoanLib.STATUS.INSOLVENT) {
+        if (s == LoanLib.STATUS.LIQUIDATABLE) {
             return _sweep(arbiter, token);
         }
 

--- a/contracts/modules/credit/SpigotedLoan.t.sol
+++ b/contracts/modules/credit/SpigotedLoan.t.sol
@@ -196,8 +196,11 @@ contract SpigotedLoanTest is Test {
     // Spigot integration tests
     // Only checking that Loan functions dont fail. Check `Spigot.t.sol` for expected functionality
 
-    function test_can_deposit_and_repay() public {
+    function test_anyone_can_deposit_and_repay() public {
       loan.borrow(loan.ids(0), lentAmount);
+      creditToken.mint(address(0xdebf), lentAmount);
+      hoax(address(0xdebf));
+      creditToken.approve(address(loan), lentAmount);
       loan.depositAndRepay(lentAmount);
     }
 

--- a/contracts/modules/credit/SpigotedLoan.t.sol
+++ b/contracts/modules/credit/SpigotedLoan.t.sol
@@ -245,7 +245,6 @@ contract SpigotedLoanTest is Test {
     // results change based on loan status (ACTIVE vs LIQUIDATABLE vs INSOLVENT)
     // Only checking that Loan functions dont fail. Check `Spigot.t.sol` for expected functionality
 
-
     // releaseSpigot()
 
     function test_release_spigot_while_active() public {
@@ -271,6 +270,7 @@ contract SpigotedLoanTest is Test {
     }
 
     // sweep()
+
 
     function test_cant_sweep_tokens_while_active() public {
       _borrow();

--- a/contracts/modules/credit/SpigotedLoan.t.sol
+++ b/contracts/modules/credit/SpigotedLoan.t.sol
@@ -1,7 +1,7 @@
 
 pragma solidity ^0.8.9;
 
-import { Test } from "forge-std/Test.sol";
+import "forge-std/Test.sol";
 import { RevenueToken } from "../../mock/RevenueToken.sol";
 import { SimpleOracle } from "../../mock/SimpleOracle.sol";
 import { ZeroEx } from "../../mock/ZeroEx.sol";
@@ -10,6 +10,8 @@ import { Spigot } from "../spigot/Spigot.sol";
 import { SpigotedLoan } from './SpigotedLoan.sol';
 import { LoanLib } from '../../utils/LoanLib.sol';
 import { ISpigot } from '../../interfaces/ISpigot.sol';
+import { ISpigotedLoan } from '../../interfaces/ISpigotedLoan.sol';
+import { ILineOfCredit } from '../../interfaces/ILineOfCredit.sol';
 
 /**
  * @notice
@@ -38,15 +40,12 @@ contract SpigotedLoanTest is Test {
     uint constant MAX_REVENUE = MAX_INT / 100;
 
     // Loan access control vars
-    address private lender;
+    address private arbiter = address(this);
+    address private borrower = address(1);
+    address private lender = address(2);
     SimpleOracle private oracle;
-    address private arbiter;
-    address private borrower;
 
     function setUp() public {
-        lender = address(this);
-        arbiter = address(this);
-        borrower = address(this);
         dex = new ZeroEx();
         creditToken = new RevenueToken();
         revenueToken = new RevenueToken();
@@ -57,21 +56,37 @@ contract SpigotedLoanTest is Test {
 
         _mintAndApprove();
         
-        // take out loan
-        loan.addCredit(drawnRate, facilityRate, lentAmount, address(creditToken), lender);
-        loan.addCredit(drawnRate, facilityRate, lentAmount, address(creditToken), lender);
-
-        ISpigot.Setting memory setting = ISpigot.Setting({
-          token: address(revenueToken),
-          ownerSplit: ownerSplit,
-          claimFunction: bytes4(0),
-          transferOwnerFunction: bytes4("1234")
-        });
-        loan.addSpigot(revenueContract, setting);
-        loan.addSpigot(revenueContract, setting);
-
+        _createCredit();
         // revenue go brrrrrrr
         spigot.claimRevenue(address(revenueContract), "");
+    }
+
+    function _createCredit() public returns(bytes32 id) {
+      ISpigot.Setting memory setting = ISpigot.Setting({
+        token: address(revenueToken),
+        ownerSplit: ownerSplit,
+        claimFunction: bytes4(0),
+        transferOwnerFunction: bytes4("1234")
+      });
+
+      startHoax(borrower);
+      creditToken.approve(address(loan), MAX_INT);
+      loan.addCredit(drawnRate, facilityRate, lentAmount, address(creditToken), lender);
+      loan.addSpigot(revenueContract, setting);
+      vm.stopPrank();
+      
+      startHoax(lender);
+      creditToken.approve(address(loan), MAX_INT);
+      id = loan.addCredit(drawnRate, facilityRate, lentAmount, address(creditToken), lender);
+      vm.stopPrank();
+
+      loan.addSpigot(revenueContract, setting);
+    }
+
+    function _borrow() public {
+      vm.startPrank(borrower);
+      loan.borrow(loan.ids(0), lentAmount);
+      vm.stopPrank();
     }
 
     function _mintAndApprove() public {
@@ -79,6 +94,7 @@ contract SpigotedLoanTest is Test {
       // seed dex with tokens to buy
       creditToken.mint(address(dex), MAX_REVENUE);
       // allow loan to use tokens for depositAndRepay()
+      creditToken.mint(lender, MAX_REVENUE);
       creditToken.mint(address(this), MAX_REVENUE);
       creditToken.approve(address(loan), MAX_INT);
       // allow trades
@@ -87,37 +103,30 @@ contract SpigotedLoanTest is Test {
 
       // tokens to trade
 
-      revenueToken.mint(address(this), MAX_REVENUE);
+      revenueToken.mint(borrower, MAX_REVENUE);
       revenueToken.mint(address(loan), MAX_REVENUE);
       revenueToken.mint(address(dex), MAX_REVENUE);
+      revenueToken.mint(address(this), MAX_REVENUE);
       revenueToken.approve(address(dex), MAX_INT);
 
       // revenue earned
       revenueToken.mint(address(spigot), MAX_REVENUE);
       // allow deposits
       revenueToken.approve(address(loan), MAX_INT);
-
     }
 
-    // TODO can only remove spigot if repaid or insolvent (propery access for both situations)
-    function testFail_trade_when_no_credit() public {
-      bytes memory tradeData = abi.encodeWithSignature(
-        'trade(address,address,uint256,uint256)',
-        address(revenueToken),
-        address(creditToken),
-        1,
-        1
-      );
 
-      loan.claimAndTrade(address(revenueToken), tradeData);
-    }
+    // claimAndTrade 
+    
+    // TODO add raw ETH tests
 
-    // trades work
+  
     function test_can_trade(uint buyAmount, uint sellAmount) public {
       // oracle prices not relevant to test
       if(buyAmount == 0 || sellAmount == 0) return;
       if(buyAmount > MAX_REVENUE || sellAmount > MAX_REVENUE) return;
       
+      vm.startPrank(borrower);
       // need to have active position so we can buy asset
       loan.borrow(loan.ids(0), buyAmount);
 
@@ -132,6 +141,8 @@ contract SpigotedLoanTest is Test {
       uint claimable = spigot.getEscrowed(address(revenueToken));
 
       loan.claimAndTrade(address(revenueToken), tradeData);
+
+      vm.stopPrank();
       
       // dex balances
       assertEq(creditToken.balanceOf((address(dex))), MAX_REVENUE - buyAmount);
@@ -142,10 +153,37 @@ contract SpigotedLoanTest is Test {
       assertEq(revenueToken.balanceOf((address(loan))), MAX_REVENUE + claimable - sellAmount);
     }
 
+    function test_cant_claim_and_trade_not_borrowing() public {
+      bytes memory tradeData = abi.encodeWithSignature(
+        'trade(address,address,uint256,uint256)',
+        address(revenueToken),
+        address(creditToken),
+        lentAmount,
+        lentAmount
+      );
+
+      vm.expectRevert(ILineOfCredit.NotBorrowing.selector);
+      loan.claimAndTrade(address(revenueToken), tradeData);
+    }
+
+    function test_cant_claim_and_repay_not_borrowing() public {
+      bytes memory tradeData = abi.encodeWithSignature(
+        'trade(address,address,uint256,uint256)',
+        address(revenueToken),
+        address(creditToken),
+        lentAmount,
+        lentAmount
+      );
+
+      vm.expectRevert(ILineOfCredit.NotBorrowing.selector);
+      loan.claimAndRepay(address(revenueToken), tradeData);
+    }
+
     function test_can_trade_and_repay(uint buyAmount, uint sellAmount) public {
       if(buyAmount == 0 || sellAmount == 0) return;
       if(buyAmount > MAX_REVENUE || sellAmount > MAX_REVENUE) return;
-
+      
+      vm.startPrank(borrower);
       loan.borrow(loan.ids(0), lentAmount);
       
       // no interest charged because no blocks processed
@@ -163,6 +201,7 @@ contract SpigotedLoanTest is Test {
       uint claimable = spigot.getEscrowed(address(revenueToken));
 
       loan.claimAndRepay(address(revenueToken), tradeData);
+      vm.stopPrank();
 
       // principal, interest, repaid
       (,uint p, uint i, uint r,,,) = loan.credits(loan.ids(0));
@@ -190,49 +229,239 @@ contract SpigotedLoanTest is Test {
       assertEq(loan.unused(address(creditToken)), unusedCreditToken);
       assertEq(loan.unused(address(revenueToken)), MAX_REVENUE + claimable - sellAmount);
     }
-
-    // check unsused balances. Do so by changing minAmountOut in trade 0
-
-    // Spigot integration tests
-    // Only checking that Loan functions dont fail. Check `Spigot.t.sol` for expected functionality
+    
+    // write tests for unused tokens
 
     function test_anyone_can_deposit_and_repay() public {
-      loan.borrow(loan.ids(0), lentAmount);
+      _borrow();
+
       creditToken.mint(address(0xdebf), lentAmount);
       hoax(address(0xdebf));
       creditToken.approve(address(loan), lentAmount);
       loan.depositAndRepay(lentAmount);
     }
 
-    function test_update_split() public {
-      loan.updateOwnerSplit(revenueContract);
+    // Spigot integration tests
+    // results change based on loan status (ACTIVE vs LIQUIDATABLE vs INSOLVENT)
+    // Only checking that Loan functions dont fail. Check `Spigot.t.sol` for expected functionality
+
+
+    // releaseSpigot()
+
+    function test_release_spigot_while_active() public {
+      assertFalse(loan.releaseSpigot());
     }
 
-    function testFail_release_spigot_while_active() public {
-      assertTrue(loan.releaseSpigot());
-    }
-
-    function test_release_spigot_when_repaid() public {
+    function test_release_spigot_to_borrower_when_repaid() public {  
+      vm.startPrank(borrower);
       loan.close(loan.ids(0));
+      vm.stopPrank();
+
       assertTrue(loan.releaseSpigot());
 
-      // TODO: bad test, will be address(this either way
       assertEq(spigot.owner(), borrower);
     }
 
+    function test_release_spigot_to_arbiter_when_liquidated() public {  
+      vm.warp(ttl+1);
+
+      assertTrue(loan.releaseSpigot());
+
+      assertEq(spigot.owner(), arbiter);
+    }
+
+    // sweep()
+
     function test_cant_sweep_tokens_while_active() public {
+      _borrow();
+      hoax(borrower);
+      uint claimed = MAX_REVENUE / ownerSplit; // expected claim amountd tokens for test
+      // create unused tokens      
+      bytes memory tradeData = abi.encodeWithSignature(
+        'trade(address,address,uint256,uint256)',
+        address(revenueToken),
+        address(creditToken),
+        claimed - 1,
+        lentAmount
+      );
+      loan.claimAndRepay(address(revenueToken), tradeData);
+      vm.stopPrank();
       assertEq(0, loan.sweep(address(creditToken))); // no tokens transfered
     }
 
-    function test_sweep_tokens_when_repaid() public {
-      assertTrue(loan.close(loan.ids(0)));
-      uint unused = loan.unused(address(creditToken));
-      assertEq(loan.sweep(address(creditToken)), unused);
+    function test_sweep_to_borrower_when_repaid() public {
+      _borrow();
+      hoax(borrower);
+
+      uint claimed = MAX_REVENUE / ownerSplit; // expected claim amount
+      bytes memory tradeData = abi.encodeWithSignature(
+        'trade(address,address,uint256,uint256)',
+        address(revenueToken),
+        address(creditToken),
+        claimed - 1,
+        lentAmount
+      );
+      loan.claimAndRepay(address(revenueToken), tradeData);
+      vm.stopPrank();
+
+      // initial mint + spigot revenue to borrower - unused
+      assertEq((MAX_REVENUE * 2) - 1, revenueToken.balanceOf(address(borrower)));
+
+
+      uint balance = revenueToken.balanceOf(address(borrower));
+
+      uint unused = loan.unused(address(revenueToken));
+      uint swept = loan.sweep(address(revenueToken));
+
+      assertEq(unused, 1); // all unused sent to arbi
+      assertEq(swept, unused); // all unused sent to arbi
+      assertEq(swept, 1);      // untraded revenue
+      assertEq(swept, revenueToken.balanceOf(address(borrower)) - balance); // arbi balance updates properly
     }
 
-    function testFail_update_split_bad_contract() public {
+    function test_sweep_to_arbiter_when_liquidated() public {
+      _borrow();
+
+      uint claimed = MAX_REVENUE / ownerSplit; // expected claim amount 
+
+      hoax(borrower);
+      bytes memory tradeData = abi.encodeWithSignature(
+        'trade(address,address,uint256,uint256)',
+        address(revenueToken),
+        address(creditToken),
+        claimed - 1,
+        lentAmount
+      );
+      loan.claimAndRepay(address(revenueToken), tradeData); 
+      vm.stopPrank();
+
+      assertEq(uint(loan.loanStatus()), uint(LoanLib.STATUS.REPAID));
+
+      uint balance = revenueToken.balanceOf(address(arbiter));
+      uint unused = loan.unused(address(revenueToken));
+
+      vm.warp(ttl+1);          // set to liquidatable
+      
+      uint swept = loan.sweep(address(revenueToken));
+      assertEq(swept, unused); // all unused sent to arbi
+      assertEq(swept, 1);      // untraded revenue
+      assertEq(swept, revenueToken.balanceOf(address(arbiter)) - balance); // arbi balance updates properly
+    }
+
+    // updateOwnerSplit()
+
+    function test_update_split_no_action_on_active() public {
+      // already at default so doesnt change
+      assertFalse(loan.updateOwnerSplit(revenueContract));
+    }
+
+    function test_update_split_no_action_on_already_liquidated() public {
+      // validate original settings
+      (,uint8 split,,) = spigot.getSetting(revenueContract);
+      assertEq(split, ownerSplit);
+      
+      // fast forward to past deadline
+      vm.warp(ttl+1);
+
+      assertTrue(loan.updateOwnerSplit(revenueContract));
+      (,uint8 split2,,) = spigot.getSetting(revenueContract);
+      assertEq(split2, 100); // to 100 since LIQUIDATABLE
+
+      // second run shouldnt updte
+      assertFalse(loan.updateOwnerSplit(revenueContract));
+      // split should still be 100%
+      (,uint8 split3,,) = spigot.getSetting(revenueContract);
+      assertEq(split3, 100);
+    }
+
+    function test_update_split_bad_contract() public {
+      vm.expectRevert(ISpigotedLoan.NoSpigot.selector);
       loan.updateOwnerSplit(address(0xdead));
     }
 
-    // TODO force loan into liquidatable to test - updateOwnerSplit, sweep, and releaseSpigot
+    function test_update_split_to_100_on_liquidate() public {
+      // fast forward to past deadline
+      vm.warp(ttl+1);
+
+      assertTrue(loan.updateOwnerSplit(revenueContract));
+      assertEq(uint(loan.loanStatus()), uint(LoanLib.STATUS.LIQUIDATABLE));
+      (,uint8 split,,) = spigot.getSetting(revenueContract);
+      assertEq(split, 100);
+    }
+
+    function test_update_split_to_default_on_active_from_liquidate() public {
+      // validate original settings
+      (,uint8 split,,) = spigot.getSetting(revenueContract);
+      assertEq(split, ownerSplit);
+      
+      // fast forward to past deadline
+      vm.warp(ttl+1);
+
+      assertTrue(loan.updateOwnerSplit(revenueContract));
+      assertEq(uint(loan.loanStatus()), uint(LoanLib.STATUS.LIQUIDATABLE));
+      (,uint8 split2,,) = spigot.getSetting(revenueContract);
+      assertEq(split2, 100); // to 100 since LIQUIDATABLE
+
+      vm.warp(1);            // sloanStatus = LIQUIDTABLE but healthcheck == ACTIVE
+      assertTrue(loan.updateOwnerSplit(revenueContract));
+      (,uint8 split3,,) = spigot.getSetting(revenueContract);
+      assertEq(split3, ownerSplit); // to default since ACTIVE
+    }
+
+    // addSpigot()
+
+    function test_cant_add_spigot_without_consent() public {
+      address rev = address(0xf1c0);
+      ISpigot.Setting memory setting = ISpigot.Setting({
+        token: address(revenueToken),
+        ownerSplit: ownerSplit,
+        claimFunction: bytes4(0),
+        transferOwnerFunction: bytes4("1234")
+      });
+
+      loan.addSpigot(rev, setting);
+      (address token,,,bytes4 transferFunc) = spigot.getSetting(rev);
+      // settings not saved on spigot contract
+      assertEq(transferFunc, bytes4(0));
+      assertEq(token, address(0));
+    }
+
+    function test_can_add_spigot_with_consent() public {
+      address rev = address(0xf1c0);
+      ISpigot.Setting memory setting = ISpigot.Setting({
+        token: address(revenueToken),
+        ownerSplit: ownerSplit,
+        claimFunction: bytes4(0),
+        transferOwnerFunction: bytes4("1234")
+      });
+
+      loan.addSpigot(rev, setting);
+      hoax(borrower);
+      loan.addSpigot(rev, setting);
+
+      (address token,uint8 split,bytes4 claim,bytes4 transfer) = spigot.getSetting(rev);
+      // settings not saved on spigot contract
+      assertEq(transfer, setting.transferOwnerFunction);
+      assertEq(claim, setting.claimFunction);
+      assertEq(token, setting.token);
+      assertEq(split, setting.ownerSplit);
+    }
+
+    // updateWhitelist
+    function test_cant_whitelist_as_anon() public {
+      hoax(address(0xdebf));
+      vm.expectRevert();
+      loan.updateWhitelist(bytes4("0000"), true);
+    }
+
+    function test_cant_whitelist_as_borrower() public {
+      hoax(borrower);
+      vm.expectRevert();
+      loan.updateWhitelist(bytes4("0000"), true);
+    }
+
+    function test_can_whitelist_as_arbiter() public {
+      assertTrue(loan.updateWhitelist(bytes4("0000"), true));
+    }
 }
+

--- a/contracts/modules/credit/SpigotedLoan.t.sol
+++ b/contracts/modules/credit/SpigotedLoan.t.sol
@@ -129,7 +129,7 @@ contract SpigotedLoanTest is Test {
         buyAmount
       );
 
-      uint claimable = spigot.getEscrowBalance(address(revenueToken));
+      uint claimable = spigot.getEscrowed(address(revenueToken));
 
       loan.claimAndTrade(address(revenueToken), tradeData);
       
@@ -160,7 +160,7 @@ contract SpigotedLoanTest is Test {
         buyAmount
       );
 
-      uint claimable = spigot.getEscrowBalance(address(revenueToken));
+      uint claimable = spigot.getEscrowed(address(revenueToken));
 
       loan.claimAndRepay(address(revenueToken), tradeData);
 

--- a/contracts/modules/credit/SpigotedLoan.t.sol
+++ b/contracts/modules/credit/SpigotedLoan.t.sol
@@ -1,7 +1,7 @@
 
 pragma solidity ^0.8.9;
 
-import { DSTest } from  "../../../lib/ds-test/src/test.sol";
+import { Test } from "forge-std/Test.sol";
 import { RevenueToken } from "../../mock/RevenueToken.sol";
 import { SimpleOracle } from "../../mock/SimpleOracle.sol";
 import { ZeroEx } from "../../mock/ZeroEx.sol";
@@ -16,7 +16,7 @@ import { ISpigot } from '../../interfaces/ISpigot.sol';
  * @dev - does not test spigot integration e.g. claimEscrow() since that should already be covered in Spigot tests
  *      - these tests would fail if that assumption was wrong anyway
  */
-contract SpigotedLoanTest is DSTest {
+contract SpigotedLoanTest is Test {
     ZeroEx dex;
     SpigotedLoan loan;
     Spigot spigot;

--- a/contracts/modules/escrow/Escrow.sol
+++ b/contracts/modules/escrow/Escrow.sol
@@ -260,7 +260,6 @@ contract Escrow is IEscrow {
         require(amount > 0);
         if(msg.sender != loan) { revert CallerAccessDenied(); }
         if(deposited[token].amount < amount) { revert InvalidCollateral(); }
-        if(minimumCollateralRatio < _getLatestCollateralRatio()) { revert NotLiquidatable(); }
 
         deposited[token].amount -= amount;
         

--- a/contracts/modules/escrow/Escrow.t.sol
+++ b/contracts/modules/escrow/Escrow.t.sol
@@ -1,14 +1,14 @@
 pragma solidity 0.8.9;
 
 import { Escrow } from "./Escrow.sol";
-import { DSTest } from  "../../../lib/ds-test/src/test.sol";
+import { Test } from "forge-std/Test.sol";
 import { LoanLib } from "../../utils/LoanLib.sol";
 import { RevenueToken } from "../../mock/RevenueToken.sol";
 import { RevenueToken4626 } from "../../mock/RevenueToken4626.sol";
 import { SimpleOracle } from "../../mock/SimpleOracle.sol";
 import { MockLoan } from "../../mock/MockLoan.sol";
 
-contract EscrowTest is DSTest {
+contract EscrowTest is Test {
 
     Escrow escrow;
     RevenueToken supportedToken1;

--- a/contracts/modules/oracle/Oracle.sol
+++ b/contracts/modules/oracle/Oracle.sol
@@ -2,18 +2,17 @@
 pragma solidity ^0.8.9;
 
 import "@chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol";
+import { Denominations } from "@chainlink/contracts/src/v0.8/Denominations.sol";
 import "../../interfaces/IOracle.sol";
 
 contract Oracle is IOracle {
-    FeedRegistryInterface internal registry;
-    address public USD = 0x0000000000000000000000000000000000000348;
-
+    FeedRegistryInterface internal registry; 
     constructor(address _registry) {
         registry = FeedRegistryInterface(_registry);
     }
 
     /**
-     * Returns the latest price in USD
+     * Returns the latest price in USD to 8 decimals
      */
     function getLatestAnswer(address token) external returns (int) {
         (
@@ -22,7 +21,7 @@ contract Oracle is IOracle {
             /* uint80 startedAt */,
             /* uint80 timeStamp */,
             /* uint80 answeredInRound */
-        ) = registry.latestRoundData(token, USD); // ALL PRICES WILL HAVE 8 DECIMAL PADDING
+        ) = registry.latestRoundData(token, Denominations.USD);
         
         return price;
     }

--- a/contracts/modules/spigot/Spigot.sol
+++ b/contracts/modules/spigot/Spigot.sol
@@ -357,7 +357,7 @@ contract Spigot is ISpigot, ReentrancyGuard {
      */
     function _updateWhitelist(bytes4 func, bool allowed) internal returns (bool) {
         whitelistedFunctions[func] = allowed;
-        emit UpdateWhitelistFunction(func, true);
+        emit UpdateWhitelistFunction(func, allowed);
         return true;
     }
 

--- a/contracts/modules/spigot/Spigot.sol
+++ b/contracts/modules/spigot/Spigot.sol
@@ -31,11 +31,11 @@ contract Spigot is ISpigot, ReentrancyGuard {
     // Spigot variables
 
     // Total amount of tokens escrowed by spigot
-    mapping(address => uint256) escrowed; // token  -> amount escrowed
+    mapping(address => uint256) private escrowed; // token  -> amount escrowed
     //  allowed by operator on all revenue contracts
-    mapping(bytes4 => bool) whitelistedFunctions; // function -> allowed
+    mapping(bytes4 => bool) private whitelistedFunctions; // function -> allowed
     // Configurations for revenue contracts to split
-    mapping(address => Setting) settings; // revenue contract -> settings
+    mapping(address => Setting) private settings; // revenue contract -> settings
 
     /**
      *
@@ -150,9 +150,19 @@ contract Spigot is ISpigot, ReentrancyGuard {
      * @notice - Retrieve amount of tokens tokens escrowed waiting for claim
      * @param token Revenue token that is being garnished from spigots
     */
-    function getEscrowBalance(address token) external view returns (uint256) {
+    function getEscrowed(address token) external view returns (uint256) {
         return escrowed[token];
     }
+
+    /**
+     * @notice - If a function is callable on revenue contracts
+     * @param func Function to check on whitelist 
+    */
+
+    function isWhitelisted(bytes4 func) external view returns(bool) {
+      return whitelistedFunctions[func];
+    }
+
 
 
 

--- a/contracts/modules/spigot/Spigot.t.sol
+++ b/contracts/modules/spigot/Spigot.t.sol
@@ -137,7 +137,7 @@ contract SpigotTest is Test {
         uint256 escrowed = maxRevenue * settings.ownerSplit / 100;
 
         assertEq(
-            spigot.getEscrowBalance(_token),
+            spigot.getEscrowed(_token),
             escrowed,
             'Invalid escrow amount for spigot revenue'
         );

--- a/contracts/modules/spigot/Spigot.t.sol
+++ b/contracts/modules/spigot/Spigot.t.sol
@@ -1,12 +1,13 @@
 pragma solidity 0.8.9;
 
+import { Test } from "forge-std/Test.sol";
 import { Spigot } from "./Spigot.sol";
-import { DSTest } from  "../../../lib/ds-test/src/test.sol";
+
 import { RevenueToken } from "../../mock/RevenueToken.sol";
 import { SimpleRevenueContract } from '../../mock/SimpleRevenueContract.sol';
 import { ISpigot } from '../../interfaces/ISpigot.sol';
 
-contract SpigotTest is DSTest {
+contract SpigotTest is Test {
     // spigot contracts/configurations to test against
     RevenueToken private token;
     address private revenueContract;

--- a/contracts/utils/LoanLib.sol
+++ b/contracts/utils/LoanLib.sol
@@ -1,12 +1,19 @@
 pragma solidity 0.8.9;
 import { IOracle } from "../interfaces/IOracle.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Denominations } from "@chainlink/contracts/src/v0.8/Denominations.sol";
+
 /**
   * @title Debt DAO P2P Loan Library
   * @author Kiba Gateaux
   * @notice Core logic and variables to be reused across all Debt DAO Marketplace loans
  */
 library LoanLib {
-    address constant DEBT_TOKEN = address(0xdebf);
+    using SafeERC20 for IERC20;
+
+    error TransferFailed();
+    error BadToken();
 
     enum STATUS {
         // ¿hoo dis
@@ -156,4 +163,62 @@ library LoanLib {
 
       return newPositions;
     }
+
+    /**
+     * @notice - Send ETH or ERC20 token from this contract to an external contract
+     * @param token - address of token to send out. Denominations.ETH for raw ETH
+     * @param receiver - address to send tokens to
+     * @param amount - amount of tokens to send
+     */
+    function sendOutTokenOrETH(
+      address token,
+      address receiver,
+      uint256 amount
+    )
+      external
+      returns (bool)
+    {
+        if(token == address(0)) { revert TransferFailed(); }
+        if(token!= Denominations.ETH) { // ERC20
+            IERC20(token).safeTransfer(receiver, amount);
+        } else { // ETH
+            payable(receiver).transfer(amount);
+        }
+        return true;
+    }
+
+    /**
+     * @notice - Send ETH or ERC20 token from this contract to an external contract
+     * @param token - address of token to send out. Denominations.ETH for raw ETH
+     * @param sender - address that is giving us tokens/ETH
+     * @param amount - amount of tokens to send
+     */
+    function receiveTokenOrETH(
+      address token,
+      address sender,
+      uint256 amount
+    )
+      external
+      returns (bool)
+    {
+        if(token == address(0)) { revert TransferFailed(); }
+        if(token!= Denominations.ETH) { // ERC20
+            IERC20(token).safeTransferFrom(sender, address(this), amount);
+        } else { // ETH
+            if(msg.value < amount) { revert TransferFailed(); }
+        }
+        return true;
+    }
+
+    /**
+     * @notice - Helper function to get current balance of this contract for ERC20 or ETH
+     * @param token - address of token to check. Denominations.ETH for raw ETH
+    */
+    function getBalance(address token) external view returns (uint256) {
+        if(token == address(0)) return 0;
+        return token != Denominations.ETH ?
+            IERC20(token).balanceOf(address(this)) :
+            address(this).balance;
+    }
+
 }

--- a/contracts/utils/LoanLib.sol
+++ b/contracts/utils/LoanLib.sol
@@ -152,7 +152,7 @@ library LoanLib {
         newPositions[i - 1] = positions[i];
       }
       // cycle first el back to end of queue
-      newPositions[len] = positions[0];
+      newPositions[len - 1] = positions[0];
 
       return newPositions;
     }

--- a/contracts/utils/LoanLib.sol
+++ b/contracts/utils/LoanLib.sol
@@ -108,18 +108,18 @@ library LoanLib {
     }
 
     /**
-     * @dev assumes that `id` is stored only once in `positions` array bc no reason for Loans to store multiple times.
-          This means cleanup on _close() and checks on addDebtPosition are CRITICAL. If `id` is duplicated then the position can't be closed
+     * @dev `id` MUST be in `positions` array ONLY ONCE.
+          This means cleanup on _close() and checks on addCredit are CRITICAL. If `id` is duplicated then the position can't be closed
      * @param positions - all current active positions on the loan
      * @param id - hash id that must be removed from active positions
      * @return newPositions - all active positions on loan after `id` is removed
      */
     function removePosition(bytes32[] calldata positions, bytes32 id) external pure returns(bytes32[] memory) {
-      uint256 newLength = positions.length - 1;
+      uint256 len = positions.length - 1;
       uint256 count = 0;
-      bytes32[] memory newPositions = new bytes32[](newLength);
+      bytes32[] memory newPositions = new bytes32[](len);
 
-      for(uint i = 0; i < positions.length; i++) {
+      for(uint i = 0; i <= len; i++) {
           if(positions[i] != id) {
               newPositions[count] = positions[i];
               count++;

--- a/contracts/utils/LoanLib.t.sol
+++ b/contracts/utils/LoanLib.t.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.8.9;
 
-import { Test } from "forge-std/Test.sol";
+import "forge-std/Test.sol";
+
 
 import { LoanLib } from "./LoanLib.sol";
 
@@ -36,11 +37,12 @@ contract LoanLibTest is Test {
         assert(newIds[0] == id);
     }
 
-    function testFail_cannot_remove_non_existent_position() public {
+    function test_remove_non_existent_position() public {
         bytes32 id = LoanLib.computePositionId(loan, lender, token);
         bytes32[] memory ids = new bytes32[](1);
         ids[0] = id;
         assert(ids.length == 1);
+        vm.expectRevert(stdError.indexOOBError);
         LoanLib.removePosition(ids, bytes32(0));
     }
 

--- a/contracts/utils/LoanLib.t.sol
+++ b/contracts/utils/LoanLib.t.sol
@@ -43,18 +43,19 @@ contract LoanLibTest is DSTest {
         LoanLib.removePosition(ids, bytes32(0));
     }
 
-    function prove_can_properly_sort_queue(uint256 amount) public {
-        if(amount == 0) { return; }
 
-        bytes32[] memory ids = new bytes32[](amount);
-        if(amount == 1) {
+    function test_can_properly_step_queue(uint256 length) public {
+        if(length == 0 || length > 200) { return; } // ensure array is within reasonable bounds
+
+        bytes32[] memory ids = new bytes32[](length);
+        if(length == 1) {
             ids[0] = bytes32(0);
             bytes32[] memory newIds = LoanLib.stepQ(ids);
             assertEq(newIds[0], ids[0]);
             return;
         }
 
-        if(amount == 2) {
+        if(length == 2) {
             ids[0] = bytes32(0);
             ids[1] = bytes32(uint(1));
 
@@ -64,15 +65,17 @@ contract LoanLibTest is DSTest {
             return;
         }
 
-        for(uint256 i = 0; i < amount; i++) {
+        for(uint256 i = 0; i < length; i++) {
           ids[i] == bytes32(i);
         }
         bytes32[] memory newIds = LoanLib.stepQ(ids);
-
-        assertEq(newIds.length, amount);
-        assertEq(ids[amount - 1], bytes32(0)); // first -> last
-        assertEq(ids[0], bytes32(uint(1))); // second -> first
-        assertEq(ids[amount - 2], bytes32(amount -1)); // last -> second last
+        
+        assertEq(newIds.length, length);
+        
+        for(uint256 i = 0; i < length; i++) {
+          if(i == 0) assertEq(ids[i], newIds[length - 1]); // first -> last
+          else assertEq(ids[i], newIds[i - 1]);    // all others move one index down
+        }
     }
 
     function test_calculates_right_price_w_decimals(int256 price, uint256 amount) public {

--- a/contracts/utils/LoanLib.t.sol
+++ b/contracts/utils/LoanLib.t.sol
@@ -1,9 +1,10 @@
 pragma solidity 0.8.9;
 
-import { DSTest } from "../../lib/ds-test/src/test.sol";
+import { Test } from "forge-std/Test.sol";
+
 import { LoanLib } from "./LoanLib.sol";
 
-contract LoanLibTest is DSTest {
+contract LoanLibTest is Test {
 
     address lender = address(0);
     address loan = address(1);

--- a/contracts/utils/MutualConsent.sol
+++ b/contracts/utils/MutualConsent.sol
@@ -14,6 +14,8 @@ abstract contract MutualConsent {
     // Mapping of upgradable units and if consent has been initialized by other party
     mapping(bytes32 => bool) public mutualConsents;
 
+    error Unauthorized();
+
     /* ============ Events ============ */
 
     event MutualConsentRegistered(
@@ -34,10 +36,7 @@ abstract contract MutualConsent {
     }
 
     function _mutualConsent(address _signerOne, address _signerTwo) internal returns(bool) {
-        require(
-            msg.sender == _signerOne || msg.sender == _signerTwo,
-            "Must be authorized address"
-        );
+        if(msg.sender != _signerOne && msg.sender != _signerTwo) { revert Unauthorized(); }
 
         address nonCaller = _getNonCaller(_signerOne, _signerTwo);
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "compile": "hardhat compile",
-    "test": "dapp test",
+    "test": "forge test",
     "docs": "hardhat docgen"
   }
 }


### PR DESCRIPTION
Forked off #88 

1. No facility fee charged on `close()` 

**What was wrong:** Fix exploit in external `close()` function where interest isn't accrued so borrower can close a line without ever paying a facility fee. 

**Context:** Originally we didn't include `_accrueInterest()` in external close function because it wouldn't make it possible to _close the position since it now owed debt, where at the beginning of the call they did not owe debt. With the inclusion of the repayment queue feature, this meant that we have to include logic in `close()` that allows skipping the repayment queue only for repaying interest when closing and ensure no principal is repaid allowing them to bypass the queue.

**How it was fixed:**  call `_accrueInterest()` at start of function like all other external functions that update balances. Require borrower pay all interest owed before closing. Position can still be closed at any time if it isn't currently in the repayment queue as long as borrower can pay the facility fee. Lender is still allowed to call the function but it will fail if the borrower hasn't approved enough tokens to LineOfCredit contract to pull interest payment.

Added [test](https://github.com/debtdao/smart-contracts/blob/35f8c7b33648d9744174d815e1d33ad65101858d/contracts/modules/credit/SecuredLoan.t.sol#L384-L405) but it wont test anything until we migrate to foundry and add in warp/punking to test change in balances (currently balance is static because borrower and lender is same address)

3. Incorrect bool value emitted on `UpdateWhitelistedFunction`

**What was wrong:** was hard coded to true 

**Context:** probably written before we allowed whitelisted functions to be delisted and missed updating the event.

**How it was fixed:** `UpdateWhitelistedFunction` now takes the function parameter `allowed` in the event instead of hardcoded true value.

.3. Payment queue not updating properly

**What was wrong:** Ids were not always moving shifting properly and calls would sometimes fail. Issue was two lines of code
1. `if(i == 0) return true;`  ([source](https://github.com/debtdao/smart-contracts/blob/955be0c0652009604383d2fb257c76a2f4e54cb9/contracts/modules/credit/LineOfCredit.sol#L692)) and 2. `newPositions[len] = positions[0]` ([source](https://github.com/debtdao/smart-contracts/blob/955be0c0652009604383d2fb257c76a2f4e54cb9/contracts/utils/LoanLib.sol#L155)) returned unexpected results in certain circumstances.

**Context:**  These occur depending on which order lines are drawn on and how many lines are available. We were not testing either of these conditions prior. The incorrect underlying assumption behind this bug is we expected the first line created to always be the first line drawn down on and all subsequent lines will be drawn down after. This obviously isn't always the case

**How it was fixed:** 1.  Initialize `nextQSpot = len - 1;` instead of 0. Although we want to find the first available spot in the queue and start looping from 0, its safer to default to adding it to the end which also avoids the false positives in certain circumastances. 2. turn `len` to `len - 1;` :/
[Added tests](https://github.com/debtdao/smart-contracts/blob/35f8c7b33648d9744174d815e1d33ad65101858d/contracts/modules/credit/SecuredLoan.t.sol#L174-L310) for these conditions where random lines are drawn down and options >4 which covers all potential code paths